### PR TITLE
Changed Version also chnaged the org name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,5 +17,5 @@ Start by forking the repository. Click the "Fork" button at the top right of the
 Once your fork is created, clone it to your local development environment using the following command:
 
 ```bash
-git clone https://github.com/Nexoral/AxioDB.git
+git clone https://github.com/nexoral/AxioDB.git
 ```

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -231,7 +231,7 @@ If you want to build the Docker image yourself:
 
 ```bash
 # Clone the repository
-git clone https://github.com/Nexoral/AxioDB.git
+git clone https://github.com/nexoral/AxioDB.git
 cd AxioDB/Docker
 
 # Build the Docker image
@@ -277,14 +277,14 @@ docker run -d \
 
 - **Official Documentation**: [https://axiodb.site/](https://axiodb.site/)
 - **NPM Package**: [https://www.npmjs.com/package/axiodb](https://www.npmjs.com/package/axiodb)
-- **GitHub Repository**: [https://github.com/Nexoral/AxioDB](https://github.com/Nexoral/AxioDB)
+- **GitHub Repository**: [https://github.com/nexoral/AxioDB](https://github.com/nexoral/AxioDB)
 - **API Reference**: Access via `http://localhost:27018/api` when container is running
 
 ## > Support
 
 For support and questions:
 
-- Open an issue on [GitHub](https://github.com/Nexoral/AxioDB/issues)
+- Open an issue on [GitHub](https://github.com/nexoral/AxioDB/issues)
 - Check the [documentation](https://axiodb.site/)
 - Visit the API reference at `http://localhost:27018/api`
 

--- a/Document/src/components/content/Community.tsx
+++ b/Document/src/components/content/Community.tsx
@@ -171,7 +171,7 @@ const Community: React.FC = () => {
                 CONTRIBUTING.md file.
               </p>
               <a
-                href="https://github.com/Nexoral/AxioDB/blob/main/CONTRIBUTING.md"
+                href="https://github.com/nexoral/AxioDB/blob/main/CONTRIBUTING.md"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 rounded-lg font-semibold shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 transition-all duration-300"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # AxioDB: The Next-Generation Caching Database for Node.js
 
 [![npm version](https://badge.fury.io/js/axiodb.svg)](https://badge.fury.io/js/axiodb)
-[![CodeQL](https://github.com/Nexoral/AxioDB/actions/workflows/github-code-scanning/codeql/badge.svg?branch=main)](https://github.com/Nexoral/AxioDB/actions/workflows/github-code-scanning/codeql)
+[![CodeQL](https://github.com/nexoral/AxioDB/actions/workflows/github-code-scanning/codeql/badge.svg?branch=main)](https://github.com/nexoral/AxioDB/actions/workflows/github-code-scanning/codeql)
 [![Socket Security](https://socket.dev/api/badge/npm/package/axiodb)](https://socket.dev/npm/package/axiodb)
-[![Push to Registry](https://github.com/Nexoral/AxioDB/actions/workflows/Push.yml/badge.svg?branch=main)](https://github.com/Nexoral/AxioDB/actions/workflows/Push.yml)
+[![Push to Registry](https://github.com/nexoral/AxioDB/actions/workflows/Push.yml/badge.svg?branch=main)](https://github.com/nexoral/AxioDB/actions/workflows/Push.yml)
 
 > **AxioDB** is a blazing-fast, production-ready caching database designed for modern Node.js applications, APIs, and frontend frameworks. It combines intelligent memory management, secure file-based storage, and seamless integration with a developer-friendly API. AxioDB was created to solve the pain points of traditional cache management, manual file I/O, and unreliable global object storage—delivering a simple, fast, and reliable solution for projects of any size.
 

--- a/Scripts/versionController.sh
+++ b/Scripts/versionController.sh
@@ -14,7 +14,7 @@ NC='\033[0m' # No Color
 LOCAL_PACKAGE_JSON="package.json"
 
 # Remote package.json URL
-REMOTE_URL="https://raw.githubusercontent.com/Nexoral/AxioDB/main/package.json"
+REMOTE_URL="https://raw.githubusercontent.com/nexoral/AxioDB/main/package.json"
 
 echo "AxioDB Version Controller"
 echo "========================="
@@ -78,7 +78,7 @@ else
   read -p "Would you like to open the GitHub repository? (y/n): " -n 1 -r
   echo
   if [[ $REPLY =~ ^[Yy]$ ]]; then
-    "$BROWSER" "https://github.com/Nexoral/AxioDB"
+    "$BROWSER" "https://github.com/nexoral/AxioDB"
   fi
   exit 1
 fi


### PR DESCRIPTION
This pull request updates all references to the GitHub repository URL to use the lowercase organization name `nexoral` instead of `Nexoral`. This change ensures consistency across documentation, scripts, badges, and links, which helps prevent issues related to case sensitivity and improves reliability for users and contributors.

Repository URL standardization:

* Updated repository clone URLs in `CONTRIBUTING.md` and `Docker/README.md` to use `https://github.com/nexoral/AxioDB.git`. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L20-R20) [[2]](diffhunk://#diff-2b56a3f9807ba5bfe6366a88f86c1d9c2f6f36d3e05bdd93451f48dbf6de051eL234-R234)
* Changed all GitHub repository and issue links in `Docker/README.md` to use the lowercase organization name.
* Modified badge URLs in `README.md` to reference `nexoral/AxioDB` for CodeQL and Push to Registry workflows.
* Updated the link to the `CONTRIBUTING.md` file in the `Community.tsx` component to use the new lowercase path.
* Changed the remote package.json URL and repository open command in `Scripts/versionController.sh` to use the lowercase organization name. [[1]](diffhunk://#diff-11074655ba3eff26d81b4f631a33cb1d64046f2b9740937c78f6deb0bbaca1c1L17-R17) [[2]](diffhunk://#diff-11074655ba3eff26d81b4f631a33cb1d64046f2b9740937c78f6deb0bbaca1c1L81-R81)