### PR TITLE
chore: update version to 2.31.101

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "2.31.100",
+  "version": "2.31.101",
   "description": "A blazing-fast, lightweight, and scalable nodejs package based DBMS for modern application. Supports schemas, encryption, and advanced query capabilities.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request makes a minor version bump to the `axiodb` package, updating its version number from `2.31.100` to `2.31.101`.