### PR TITLE
Maintainer/ankan

### DIFF
--- a/.github/workflows/Push.yml
+++ b/.github/workflows/Push.yml
@@ -10,19 +10,53 @@ on:
       - 'package-lock.json'
       - 'tsconfig.json'
       - 'Docker/**'
+      - 'GUI/**'
+      - 'Test/**'
+      - 'Scripts/**'
 
 permissions:
   id-token: write  # Required for OIDC
   contents: read
 
 jobs:
+  detect_changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run_test: ${{ steps.filter.outputs.test_scripts == 'true' || steps.filter.outputs.main == 'true' || steps.filter.outputs.docker == 'true' }}
+      run_npm_github: ${{ steps.filter.outputs.main == 'true' }}
+      run_docker: ${{ steps.filter.outputs.docker == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            test_scripts:
+              - 'Test/**'
+              - 'Scripts/**'
+            main:
+              - 'GUI/**'
+              - 'source/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.json'
+            docker:
+              - 'Docker/**'
+
   test:
+    needs: [detect_changes]
+    if: needs.detect_changes.outputs.run_test == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
       matrix:
-        node-version: [20.x, 21.x, 22.x, 23.x, 24.x]
+        node-version: [20.x, 21.x, 22.x, 23.x, 24.x, 25.x, 26.x]
       fail-fast: false  # Continue testing other versions even if one fails
     name: Test (Node ${{ matrix.node-version }})
     steps:
@@ -60,7 +94,8 @@ jobs:
         run: npm test read
 
   publish_to_npm:
-    needs: [test]
+    needs: [detect_changes, test]
+    if: needs.detect_changes.outputs.run_npm_github == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -76,7 +111,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Ensure npm 11.5.1 or later
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci
@@ -94,7 +129,8 @@ jobs:
         run: npm publish --access public
 
   publish_to_github:
-    needs: [test]
+    needs: [detect_changes, test]
+    if: needs.detect_changes.outputs.run_npm_github == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -120,7 +156,8 @@ jobs:
         run: npm publish --registry=https://npm.pkg.github.com --scope=@${{ secrets.GIT_USER_NAME }} --access public
 
   publish_to_dockerhub:
-    needs: [publish_to_npm]
+    needs: [detect_changes, test]
+    if: needs.detect_changes.outputs.run_docker == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/auto_ci.yml
+++ b/.github/workflows/auto_ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 21.x, 22.x, 23.x, 24.x]
+        node-version: [20.x, 21.x, 22.x, 23.x, 24.x, 25.x, 26.x]
       fail-fast: false  # Continue testing other versions even if one fails
     name: Test (Node ${{ matrix.node-version }})
     steps:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Socket Security](https://socket.dev/api/badge/npm/package/axiodb)](https://socket.dev/npm/package/axiodb)
 
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](https://nodejs.org)
-[![Tested on Node.js](https://img.shields.io/badge/tested%20on-20%20%7C%2021%20%7C%2022%20%7C%2023%20%7C%2024%20(all%20LTS)-blue)](https://github.com/nexoral/AxioDB/actions/workflows/Push.yml)
+[![Tested on Node.js](https://img.shields.io/badge/tested%20on-20%20%7C%2021%20%7C%2022%20%7C%2023%20%7C%2024%20%7C%2025%20%7C%2026-blue)](https://github.com/nexoral/AxioDB/actions/workflows/Push.yml)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.6-blue)](https://www.typescriptlang.org/)
 [![Zero Dependencies](https://img.shields.io/badge/dependencies-0%20native-success)](https://www.npmjs.com/package/axiodb)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "9.7.7",
+  "version": "9.7.8",
   "description": "The Pure JavaScript Alternative to SQLite. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "target": "ES6", // Specify ECMAScript target version
     "module": "CommonJS", // Specify module code generation
     "declaration": true, // Generate declaration files
-    "moduleResolution": "Node", // Specify module resolution strategy
     "checkJs": false, // Disable checking of JavaScript files
     "allowJs": true, // Allow JavaScript files to be included
     "sourceMap": true, // Generate source maps


### PR DESCRIPTION
This pull request updates the CI/CD workflows to improve efficiency by only running jobs when relevant files change, expands Node.js version support, and ensures consistency across documentation and configuration files.

**Workflow optimizations:**

* Added a new `detect_changes` job to `.github/workflows/Push.yml` that uses `dorny/paths-filter` to determine which parts of the workflow should run based on file changes. Subsequent jobs (`test`, `publish_to_npm`, `publish_to_github`, `publish_to_dockerhub`) are now conditionally executed depending on the files modified, reducing unnecessary workflow runs. [[1]](diffhunk://#diff-180b61bac3d21c7729f3321b6baa42797689cd3c14dda9e37714170b684fc19dR13-R59) [[2]](diffhunk://#diff-180b61bac3d21c7729f3321b6baa42797689cd3c14dda9e37714170b684fc19dL63-R98) [[3]](diffhunk://#diff-180b61bac3d21c7729f3321b6baa42797689cd3c14dda9e37714170b684fc19dL97-R133) [[4]](diffhunk://#diff-180b61bac3d21c7729f3321b6baa42797689cd3c14dda9e37714170b684fc19dL123-R160)

**Node.js version support:**

* Expanded the Node.js test matrix in both `.github/workflows/Push.yml` and `.github/workflows/auto_ci.yml` to include versions 25.x and 26.x, ensuring compatibility with the latest Node.js releases. [[1]](diffhunk://#diff-180b61bac3d21c7729f3321b6baa42797689cd3c14dda9e37714170b684fc19dR13-R59) [[2]](diffhunk://#diff-4287a9b5dc3e126354df6b12654981a579e22bb6aa5869b6c2a5c6a30e4dc93dL16-R16)
* Updated the tested Node.js versions badge in `README.md` to reflect the expanded version support.

**Dependency management:**

* Updated the npm version installation step in the publish jobs to explicitly use npm 11 (`npm install -g npm@11`) for consistency and to avoid any issues with the latest npm releases.

**Version bump:**

* Bumped the package version from `9.7.7` to `9.7.8` in `package.json` to reflect these changes.