### PR TITLE
feat: add MCP server for AI integration & critical bug fixes

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -4,8 +4,10 @@ FROM node:22-alpine
 # Set working directory
 WORKDIR /app
 
-# Copy the runner.js and healthcheck.js files
-COPY runner.js healthcheck.js ./
+# Copy the runner.js, healthcheck.js, and mcpServer.js files, plus its feature-based
+# tool modules (mcp/tools/*.js - see mcp/shared.helpers.js for the shared session/RBAC gates)
+COPY runner.js healthcheck.js mcpServer.js ./
+COPY mcp/ ./mcp/
 
 # Copy lib folder with proper directory structure
 COPY lib/ ./lib/
@@ -22,14 +24,19 @@ RUN apk add --no-cache bash
 # Install dependencies
 RUN npm install --force
 
+# MCP server dependencies - installed only in this image layer, never added to the
+# published axiodb npm package's own package.json/lock (library consumers embedding AxioDB
+# directly never pull these in). Opt-in at runtime via AXIODB_MCP=true.
+RUN npm install --force @modelcontextprotocol/sdk@^1.29.0 zod@^4.0.0
+
 # Run as a dedicated non-root user rather than the container default (root). Created after
 # `npm install` so the install step itself (which may need to write to root-owned paths, e.g.
 # via the postinstall script) is unaffected; ownership is handed over before the app runs.
 RUN addgroup -S axiodb && adduser -S axiodb -G axiodb && chown -R axiodb:axiodb /app
 USER axiodb
 
-# HTTP GUI (27018) and AxioDBCloud TCP (27019)
-EXPOSE 27018 27019
+# HTTP GUI (27018), AxioDBCloud TCP (27019), MCP server (27020)
+EXPOSE 27018 27019 27020
 
 # Default configuration - override any of these at `docker run` time with
 # `-e VAR=value` (or in docker-compose's `environment:` block); no rebuild required.
@@ -38,6 +45,12 @@ ENV AXIODB_TCP=true
 ENV AXIODB_TCP_AUTH=true
 ENV AXIODB_TLS=false
 ENV AXIODB_ROOT_NAME=AxioDB
+ENV AXIODB_MCP=false
+ENV AXIODB_MCP_PORT=27020
+
+# MCP tools require a logged-in session (default admin/admin, same as the GUI), so
+# AXIODB_MCP=true only takes effect when the RBAC seeder actually runs - i.e. AXIODB_GUI=true
+# or (AXIODB_TCP=true and AXIODB_TCP_AUTH=true).
 
 # To enable TLS on the TCP server, set AXIODB_TLS=true and mount a cert/key pair into the
 # container, then point these at the mounted paths, e.g.:
@@ -46,9 +59,9 @@ ENV AXIODB_ROOT_NAME=AxioDB
 # ENV AXIODB_TLS_CERT_PATH=/certs/server.crt
 # ENV AXIODB_TLS_KEY_PATH=/certs/server.key
 
-# Probes whichever of the GUI (/health) and TCP (real PING/PONG heartbeat) surfaces are
-# enabled - see healthcheck.js. Reported via `docker ps` / `docker inspect` and consumed by
-# docker-compose's `depends_on: condition: service_healthy`.
+# Probes whichever of the GUI (/health), TCP (real PING/PONG heartbeat), and MCP (Streamable
+# HTTP liveness) surfaces are enabled - see healthcheck.js. Reported via `docker ps` /
+# `docker inspect` and consumed by docker-compose's `depends_on: condition: service_healthy`.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD ["node", "healthcheck.js"]
 

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -9,6 +9,7 @@ This Docker image provides both a REST API server and TCP remote access for Axio
 
 - **REST API Server**: Full HTTP API for database operations (Port 27018)
 - **TCP Remote Access**: AxioDBCloud connector for remote client connections (Port 27019)
+- **MCP Server**: Opt-in AI agent integration (Claude, or any MCP-compatible client) over Streamable HTTP (Port 27020)
 - **Web GUI Dashboard**: Browser-based interface at `http://localhost:27018`
 - **API Documentation**: Interactive API reference at `http://localhost:27018/api`
 - **AxioDB Core**: Complete database management system
@@ -194,6 +195,8 @@ main();
 | `AXIODB_TCP_AUTH` | `true` | Require username/password authentication on TCP connections (same RBAC accounts as the GUI) |
 | `AXIODB_ROOT_NAME` | `AxioDB` | Name of the root database folder created under the data volume |
 | `AXIODB_CUSTOM_PATH` | *(container's working directory)* | Custom path for database storage inside the container |
+| `AXIODB_MCP` | `false` | Enable the MCP server (AI agent integration) on port 27020 |
+| `AXIODB_MCP_PORT` | `27020` | Port the MCP server listens on inside the container |
 
 ```bash
 docker run -d \
@@ -246,6 +249,58 @@ volumes:
 ```bash
 docker compose up -d
 ```
+
+## > MCP Server (AI Agent Integration)
+
+Set `AXIODB_MCP=true` on this same container to let Claude (or any MCP-compatible AI agent)
+talk to your AxioDB instance directly, over Streamable HTTP on port 27020. It runs in the same
+process as the GUI/TCP server already in this image - no separate install, no second database
+instance.
+
+```bash
+docker run -d \
+  --name axiodb-server \
+  -e AXIODB_GUI=true \
+  -e AXIODB_MCP=true \
+  -p 27018:27018 \
+  -p 27019:27019 \
+  -p 27020:27020 \
+  -v axiodb-data:/app \
+  theankansaha/axiodb
+```
+
+Register the endpoint (`http://localhost:27020/mcp`) with whichever AI tool you use:
+
+| Tool | How |
+| --- | --- |
+| **Claude Code** | `claude mcp add --transport http axiodb http://localhost:27020/mcp` |
+| **OpenAI Codex CLI** | `codex mcp add axiodb --url http://localhost:27020/mcp` (or `[mcp_servers.axiodb]` + `url = "..."` in `~/.codex/config.toml`) |
+| **opencode** | `opencode mcp add` (interactive → type "remote") or add `"axiodb": { "type": "remote", "url": "...", "enabled": true }` under `mcp` in `opencode.json` |
+| **GitHub Copilot CLI** | `/mcp add` inside the `copilot` REPL, or add to `~/.copilot/mcp-config.json`: `{ "mcpServers": { "axiodb": { "type": "http", "url": "..." } } }` |
+| **Cursor** | Add to `.cursor/mcp.json` (or `~/.cursor/mcp.json`): `{ "mcpServers": { "axiodb": { "url": "..." } } }` |
+| **Windsurf** | Add to `~/.codeium/windsurf/mcp_config.json`: `{ "mcpServers": { "axiodb": { "serverUrl": "..." } } }` |
+| **Google Antigravity** (IDE & CLI) | Add to `~/.gemini/config/mcp_config.json`: `{ "mcpServers": { "axiodb": { "serverUrl": "..." } } }` — note `serverUrl`, not `url` |
+
+**32 tools**, covering:
+
+- **Session**: `axiodb_login`, `axiodb_logout`, `axiodb_whoami`, `axiodb_change_own_password`
+- **Database**: create/delete/exists/instance-info
+- **Collection**: create (plain or AES-256 encrypted)/delete/exists/info
+- **Documents & Aggregation**: insert/insert-many/query/update/delete/count/aggregate
+- **Index**: create/drop/list
+- **Dashboard**: stats
+- **User & Role Management**: full CRUD on users and roles, Super Admin only
+
+Every tool except `axiodb_login` requires a `sessionId` from a successful login - every
+subsequent call is checked against that logged-in user's actual RBAC role, exactly like the
+HTTP API. Nothing is gated by a static container environment variable. `AXIODB_MCP=true` only
+has RBAC to serve once it's actually seeded, i.e. `AXIODB_GUI=true` (default) or
+`AXIODB_TCP=true` + `AXIODB_TCP_AUTH=true`.
+
+Transactions and database export/import are intentionally not exposed as MCP tools.
+
+Full tool catalogue, request/response examples, and security notes:
+**[https://axiodb.in/mcp-server](https://axiodb.in/mcp-server)**.
 
 ## =� API Examples
 

--- a/Docker/healthcheck.js
+++ b/Docker/healthcheck.js
@@ -10,22 +10,26 @@ function parseBoolean(value, fallback) {
 const guiEnabled = parseBoolean(process.env.AXIODB_GUI, true);
 const tcpEnabled = parseBoolean(process.env.AXIODB_TCP, true);
 const tlsEnabled = parseBoolean(process.env.AXIODB_TLS, false);
+const mcpEnabled = parseBoolean(process.env.AXIODB_MCP, false);
+const mcpPort = parseInt(process.env.AXIODB_MCP_PORT || '27020', 10);
 const CHECK_TIMEOUT_MS = 4000;
 
 function checkGui() {
   return new Promise((resolve, reject) => {
     const request = http.get(
-      { host: 'localhost', port: 27018, path: '/health', timeout: CHECK_TIMEOUT_MS },
+      // The whole API router mounts under /api (see server/config/server.ts), so the real
+      // health route is /api/health, not /health.
+      { host: 'localhost', port: 27018, path: '/api/health', timeout: CHECK_TIMEOUT_MS },
       (response) => {
         response.resume(); // drain body, we only care about the status code
         if (response.statusCode && response.statusCode >= 200 && response.statusCode < 300) {
           resolve();
         } else {
-          reject(new Error(`GUI /health returned status ${response.statusCode}`));
+          reject(new Error(`GUI /api/health returned status ${response.statusCode}`));
         }
       },
     );
-    request.on('timeout', () => request.destroy(new Error('GUI /health request timed out')));
+    request.on('timeout', () => request.destroy(new Error('GUI /api/health request timed out')));
     request.on('error', reject);
   });
 }
@@ -60,10 +64,28 @@ function checkTcp() {
     .finally(() => client.disconnect().catch(() => {}));
 }
 
+function checkMcp() {
+  // The MCP endpoint only speaks Streamable HTTP JSON-RPC, not a plain REST health route -
+  // a GET without an active Mcp-Session-Id deterministically gets a 400 from the transport
+  // (see mcpServer.js), which is sufficient proof the process is up and listening.
+  return new Promise((resolve, reject) => {
+    const request = http.get(
+      { host: 'localhost', port: mcpPort, path: '/mcp', timeout: CHECK_TIMEOUT_MS },
+      (response) => {
+        response.resume();
+        resolve();
+      },
+    );
+    request.on('timeout', () => request.destroy(new Error('MCP /mcp request timed out')));
+    request.on('error', reject);
+  });
+}
+
 async function main() {
   const checks = [];
   if (guiEnabled) checks.push(checkGui());
   if (tcpEnabled) checks.push(checkTcp());
+  if (mcpEnabled) checks.push(checkMcp());
 
   if (checks.length === 0) {
     // Neither surface is enabled - nothing meaningful to probe, so the container is

--- a/Docker/mcp/shared.helpers.js
+++ b/Docker/mcp/shared.helpers.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// Shared plumbing for every tool module under mcp/tools/: MCP result formatting, and the
+// session/RBAC gates every tool handler passes through before touching the AxioDB instance.
+
+const { z } = require('zod');
+const SessionStore = require('../lib/Services/Auth/SessionStore.service').default;
+const PermissionChecker = require('../lib/Services/Auth/PermissionChecker.helper').default;
+
+const sessionIdField = { sessionId: z.string().min(1).describe('Session ID returned by axiodb_login') };
+
+// sendResponse() (used by the Auth/User/Role controllers) only ever calls reply.code(...)
+// and returns the response body - a real Fastify reply is never needed here.
+const NOOP_REPLY = { code() {} };
+
+function toolText(payload) {
+  return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] };
+}
+
+function errorResult(statusCode, message) {
+  return { ...toolText({ statusCode, message }), isError: true };
+}
+
+function toolResult(response) {
+  const statusCode = response && typeof response.statusCode === 'number' ? response.statusCode : 200;
+  return { ...toolText(response), isError: statusCode >= 400 };
+}
+
+/** Looks up and touches (extends the TTL of) a session, or returns null if it's gone/expired. */
+function resolveSession(sessionId) {
+  const session = SessionStore.getSession(sessionId);
+  if (session) {
+    SessionStore.touchSession(session.sid);
+  }
+  return session;
+}
+
+/** Shared error handling + response formatting for every tool handler. */
+function wrapTool(fn) {
+  return async (args) => {
+    try {
+      const response = await fn(args);
+      return toolResult(response);
+    } catch (error) {
+      return errorResult(500, error instanceof Error ? error.message : String(error));
+    }
+  };
+}
+
+/**
+ * Wraps a tool handler with session validation + RBAC permission checks, mirroring exactly
+ * what `requireAuth` + `requirePermission` do for each HTTP route (see
+ * source/server/middleware/{auth,permission}.middleware.ts). `permissionKey === null` is
+ * reserved for `axiodb_login` itself, which is the permission gate.
+ */
+function withAuth(permissionKey, handler) {
+  return wrapTool(async (args) => {
+    if (permissionKey === null) {
+      return handler(args);
+    }
+    const session = resolveSession(args.sessionId);
+    if (!session) {
+      return { statusCode: 401, message: 'Invalid or expired session. Call axiodb_login first.' };
+    }
+    if (!PermissionChecker.roleHasPermission(session.role, permissionKey)) {
+      return {
+        statusCode: 403,
+        message: `Role "${session.role}" does not have permission "${permissionKey}"`,
+      };
+    }
+    return handler(args, session);
+  });
+}
+
+/**
+ * Wraps a tool handler that only needs a valid session, not a specific permission - mirrors
+ * the HTTP GUI's self-service auth routes (`/auth/logout`, `/auth/me`,
+ * `/auth/change-password`), which are gated by `requireAuth` alone, no `requirePermission`.
+ */
+function withSession(handler) {
+  return wrapTool(async (args) => {
+    const session = resolveSession(args.sessionId);
+    if (!session) {
+      return { statusCode: 401, message: 'Invalid or expired session. Call axiodb_login first.' };
+    }
+    return handler(args, session);
+  });
+}
+
+module.exports = { sessionIdField, NOOP_REPLY, withAuth, withSession };

--- a/Docker/mcp/tools/auth.tools.js
+++ b/Docker/mcp/tools/auth.tools.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const { z } = require('zod');
+const AuthService = require('../../lib/Services/Auth/AuthService.service').default;
+const SessionStore = require('../../lib/Services/Auth/SessionStore.service').default;
+const PermissionChecker = require('../../lib/Services/Auth/PermissionChecker.helper').default;
+const LoginRateLimiter = require('../../lib/Services/Auth/LoginRateLimiter.service').default;
+const AuthEvents = require('../../lib/Services/Auth/AuthEvents.service').default;
+const { sessionIdField, withAuth, withSession } = require('../shared.helpers');
+
+module.exports = function registerAuthTools(server) {
+  const authService = new AuthService();
+
+  server.registerTool(
+    'axiodb_login',
+    {
+      description: 'Log in with an AxioDB username/password and obtain a sessionId required by every other tool. Default seeded account: admin/admin (forces a password change on first login, same as the web GUI).',
+      inputSchema: { username: z.string().min(1), password: z.string().min(1) },
+    },
+    withAuth(null, async ({ username, password }) => {
+      const cooldownRemaining = LoginRateLimiter.getCooldownRemaining('mcp');
+      if (cooldownRemaining > 0) {
+        return {
+          statusCode: 429,
+          message: `Too many failed login attempts. Try again in ${Math.ceil(cooldownRemaining / 1000)}s.`,
+        };
+      }
+
+      const result = await authService.login(username, password);
+      if (!result.success || !result.user) {
+        LoginRateLimiter.recordFailure('mcp');
+        return { statusCode: 401, message: result.message };
+      }
+      LoginRateLimiter.recordSuccess('mcp');
+
+      const session = SessionStore.createSession(
+        result.user.username,
+        result.user.role,
+        result.user.mustChangePassword,
+      );
+      return {
+        statusCode: 200,
+        message: 'Login successful',
+        data: {
+          sessionId: session.sid,
+          username: result.user.username,
+          role: result.user.role,
+          permissions: PermissionChecker.getPermissionsForRole(result.user.role),
+          mustChangePassword: result.user.mustChangePassword,
+        },
+      };
+    }),
+  );
+
+  server.registerTool(
+    'axiodb_logout',
+    {
+      description: 'Log out and invalidate a session. Sessions live in server memory only (24h TTL) - always call this when finished with a session to free it early rather than waiting for expiry.',
+      inputSchema: { ...sessionIdField },
+    },
+    withSession((args, session) => {
+      SessionStore.revokeSession(session.sid);
+      return { statusCode: 200, message: 'Logged out successfully' };
+    }),
+  );
+
+  server.registerTool(
+    'axiodb_whoami',
+    {
+      description: 'Get the identity, role, and effective permissions of the currently logged-in session.',
+      inputSchema: { ...sessionIdField },
+    },
+    withSession((args, session) => ({
+      statusCode: 200,
+      message: 'OK',
+      data: {
+        username: session.username,
+        role: session.role,
+        mustChangePassword: session.mustChangePassword,
+        permissions: PermissionChecker.getPermissionsForRole(session.role),
+      },
+    })),
+  );
+
+  server.registerTool(
+    'axiodb_change_own_password',
+    {
+      description: 'Change the password for the currently logged-in user. Revokes the old session and returns a new sessionId to use afterward.',
+      inputSchema: {
+        ...sessionIdField,
+        currentPassword: z.string().min(1),
+        newPassword: z.string().min(4),
+      },
+    },
+    withSession(async ({ currentPassword, newPassword }, session) => {
+      const result = await authService.changeOwnPassword(
+        session.username,
+        currentPassword,
+        newPassword,
+      );
+      if (!result.success) {
+        return { statusCode: 400, message: result.message };
+      }
+
+      // Rotate the session, matching AuthController.changePassword's HTTP behavior.
+      SessionStore.revokeSessionsForUser(session.username);
+      AuthEvents.emit('user-revoked', session.username);
+      const newSession = SessionStore.createSession(session.username, session.role, false);
+
+      return {
+        statusCode: 200,
+        message: 'Password changed successfully',
+        data: {
+          sessionId: newSession.sid,
+          username: session.username,
+          role: session.role,
+          permissions: PermissionChecker.getPermissionsForRole(session.role),
+          mustChangePassword: false,
+        },
+      };
+    }),
+  );
+};

--- a/Docker/mcp/tools/collection.tools.js
+++ b/Docker/mcp/tools/collection.tools.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const { z } = require('zod');
+const CollectionController = require('../../lib/server/controller/Collections/Collection.controller').default;
+const { PERMISSIONS } = require('../../lib/config/Keys/Permissions');
+const { sessionIdField, withAuth } = require('../shared.helpers');
+
+module.exports = function registerCollectionTools(server, axioDBInstance) {
+  const collectionController = new CollectionController(axioDBInstance);
+
+  server.registerTool(
+    'axiodb_create_collection',
+    {
+      description: 'Create a new collection inside a database, optionally with AES-256 encryption.',
+      inputSchema: {
+        ...sessionIdField,
+        dbName: z.string().min(1),
+        collectionName: z.string().min(1),
+        crypto: z.boolean().optional(),
+        key: z.string().optional(),
+      },
+    },
+    withAuth(PERMISSIONS.COLLECTION_CREATE, ({ dbName, collectionName, crypto, key }) =>
+      collectionController.createCollection({ body: { dbName, collectionName, crypto, key } }),
+    ),
+  );
+
+  server.registerTool(
+    'axiodb_delete_collection',
+    {
+      description: 'Delete a collection from a database.',
+      inputSchema: { ...sessionIdField, dbName: z.string().min(1), collectionName: z.string().min(1) },
+    },
+    withAuth(PERMISSIONS.COLLECTION_DELETE, ({ dbName, collectionName }) =>
+      collectionController.deleteCollection({ query: { dbName, collectionName } }),
+    ),
+  );
+
+  server.registerTool(
+    'axiodb_collection_exists',
+    {
+      description: 'Check whether a collection exists inside a database.',
+      inputSchema: { ...sessionIdField, dbName: z.string().min(1), collectionName: z.string().min(1) },
+    },
+    withAuth(PERMISSIONS.COLLECTION_VIEW, async ({ dbName, collectionName }) => {
+      const databaseInstance = await axioDBInstance.createDB(dbName);
+      const exists = await databaseInstance.isCollectionExists(collectionName);
+      return { statusCode: 200, message: 'OK', data: { dbName, collectionName, exists } };
+    }),
+  );
+
+  server.registerTool(
+    'axiodb_get_collection_info',
+    {
+      description: 'Get the list of collections in a database, with per-collection file counts.',
+      inputSchema: { ...sessionIdField, databaseName: z.string().min(1) },
+    },
+    withAuth(PERMISSIONS.COLLECTION_VIEW, ({ databaseName }) =>
+      collectionController.getCollections({ query: { databaseName } }),
+    ),
+  );
+};

--- a/Docker/mcp/tools/dashboard.tools.js
+++ b/Docker/mcp/tools/dashboard.tools.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const StatsController = require('../../lib/server/controller/Stats.controller').default;
+const { PERMISSIONS } = require('../../lib/config/Keys/Permissions');
+const { sessionIdField, withAuth } = require('../shared.helpers');
+
+module.exports = function registerDashboardTools(server, axioDBInstance) {
+  const statsController = new StatsController(axioDBInstance);
+
+  server.registerTool(
+    'axiodb_get_dashboard_stats',
+    {
+      description: 'Get aggregate instance stats: database/collection/document counts, storage usage, and cache usage.',
+      inputSchema: { ...sessionIdField },
+    },
+    withAuth(PERMISSIONS.DASHBOARD_VIEW, () => statsController.getDashBoardStat()),
+  );
+};

--- a/Docker/mcp/tools/database.tools.js
+++ b/Docker/mcp/tools/database.tools.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { z } = require('zod');
+const DatabaseController = require('../../lib/server/controller/Database/Databse.controller').default;
+const { PERMISSIONS } = require('../../lib/config/Keys/Permissions');
+const { sessionIdField, withAuth } = require('../shared.helpers');
+
+module.exports = function registerDatabaseTools(server, axioDBInstance) {
+  const dbController = new DatabaseController(axioDBInstance);
+
+  server.registerTool(
+    'axiodb_create_database',
+    {
+      description: 'Create a new AxioDB database.',
+      inputSchema: { ...sessionIdField, name: z.string().min(1) },
+    },
+    withAuth(PERMISSIONS.DB_CREATE, ({ name }) =>
+      dbController.createDatabase({ body: { name } }),
+    ),
+  );
+
+  server.registerTool(
+    'axiodb_delete_database',
+    {
+      description: 'Delete an AxioDB database.',
+      inputSchema: { ...sessionIdField, dbName: z.string().min(1) },
+    },
+    withAuth(PERMISSIONS.DB_DELETE, ({ dbName }) =>
+      dbController.deleteDatabase({ query: { dbName } }),
+    ),
+  );
+
+  server.registerTool(
+    'axiodb_database_exists',
+    {
+      description: 'Check whether a database exists.',
+      inputSchema: { ...sessionIdField, name: z.string().min(1) },
+    },
+    withAuth(PERMISSIONS.DB_VIEW, async ({ name }) => {
+      const exists = await axioDBInstance.isDatabaseExists(name);
+      return { statusCode: 200, message: 'OK', data: { name, exists } };
+    }),
+  );
+
+  server.registerTool(
+    'axiodb_get_instance_info',
+    {
+      description: 'Get the list of databases and instance-level storage info.',
+      inputSchema: { ...sessionIdField },
+    },
+    withAuth(PERMISSIONS.DB_VIEW, () => dbController.getDatabases()),
+  );
+};

--- a/Docker/mcp/tools/document.tools.js
+++ b/Docker/mcp/tools/document.tools.js
@@ -1,0 +1,151 @@
+'use strict';
+
+const { z } = require('zod');
+const CRUDController = require('../../lib/server/controller/Operation/CRUD.controller').default;
+const { PERMISSIONS } = require('../../lib/config/Keys/Permissions');
+const { sessionIdField, withAuth } = require('../shared.helpers');
+
+module.exports = function registerDocumentTools(server, axioDBInstance) {
+  const crudController = new CRUDController(axioDBInstance);
+
+  server.registerTool(
+    'axiodb_insert_document',
+    {
+      description: 'Insert a single document into a collection.',
+      inputSchema: {
+        ...sessionIdField,
+        dbName: z.string().min(1),
+        collectionName: z.string().min(1),
+        document: z.record(z.string(), z.any()),
+      },
+    },
+    withAuth(PERMISSIONS.DOCUMENT_CREATE, ({ dbName, collectionName, document }) =>
+      crudController.createNewDocument({ query: { dbName, collectionName }, body: document }),
+    ),
+  );
+
+  server.registerTool(
+    'axiodb_insert_many_documents',
+    {
+      description: 'Insert multiple documents into a collection in one call.',
+      inputSchema: {
+        ...sessionIdField,
+        dbName: z.string().min(1),
+        collectionName: z.string().min(1),
+        documents: z.array(z.record(z.string(), z.any())).min(1),
+      },
+    },
+    withAuth(PERMISSIONS.DOCUMENT_CREATE, ({ dbName, collectionName, documents }) =>
+      crudController.createManyNewDocument({ query: { dbName, collectionName }, body: documents }),
+    ),
+  );
+
+  server.registerTool(
+    'axiodb_query_documents',
+    {
+      description: 'Read documents from a collection: by documentId, by a MongoDB-style filter query, or paginated (page defaults to 1, 10 per page) when neither is given.',
+      inputSchema: {
+        ...sessionIdField,
+        dbName: z.string().min(1),
+        collectionName: z.string().min(1),
+        documentId: z.string().optional(),
+        query: z.record(z.string(), z.any()).optional(),
+        page: z.number().int().min(1).optional(),
+      },
+    },
+    withAuth(PERMISSIONS.DOCUMENT_QUERY, ({ dbName, collectionName, documentId, query, page }) => {
+      if (documentId) {
+        return crudController.getDocumentsById({ query: { dbName, collectionName, documentId } });
+      }
+      if (query) {
+        return crudController.getDocumentsByQuery({
+          query: { dbName, collectionName, page: page || 1 },
+          body: { query },
+        });
+      }
+      return crudController.getAllDocuments({ query: { dbName, collectionName, page: page || 1 } });
+    }),
+  );
+
+  server.registerTool(
+    'axiodb_update_document',
+    {
+      description: 'Update a document by documentId, or by a filter query (set `many: true` to update all matches, otherwise only the first match is updated).',
+      inputSchema: {
+        ...sessionIdField,
+        dbName: z.string().min(1),
+        collectionName: z.string().min(1),
+        documentId: z.string().optional(),
+        query: z.record(z.string(), z.any()).optional(),
+        update: z.record(z.string(), z.any()),
+        many: z.boolean().optional(),
+      },
+    },
+    withAuth(PERMISSIONS.DOCUMENT_UPDATE, ({ dbName, collectionName, documentId, query, update, many }) => {
+      if (documentId) {
+        return crudController.updateDocumentById({
+          query: { dbName, collectionName, documentId },
+          body: update,
+        });
+      }
+      return crudController.updateDocumentByQuery({
+        query: { dbName, collectionName, isMany: !!many },
+        body: { query: query || {}, update },
+      });
+    }),
+  );
+
+  server.registerTool(
+    'axiodb_delete_document',
+    {
+      description: 'Delete a document by documentId, or by a filter query (set `many: true` to delete all matches, otherwise only the first match is deleted).',
+      inputSchema: {
+        ...sessionIdField,
+        dbName: z.string().min(1),
+        collectionName: z.string().min(1),
+        documentId: z.string().optional(),
+        query: z.record(z.string(), z.any()).optional(),
+        many: z.boolean().optional(),
+      },
+    },
+    withAuth(PERMISSIONS.DOCUMENT_DELETE, ({ dbName, collectionName, documentId, query, many }) => {
+      if (documentId) {
+        return crudController.deleteDocumentById({ query: { dbName, collectionName, documentId } });
+      }
+      return crudController.deleteDocumentByQuery({
+        query: { dbName, collectionName, isMany: !!many },
+        body: { query: query || {} },
+      });
+    }),
+  );
+
+  server.registerTool(
+    'axiodb_total_documents',
+    {
+      description: 'Get the total document count in a collection.',
+      inputSchema: { ...sessionIdField, dbName: z.string().min(1), collectionName: z.string().min(1) },
+    },
+    withAuth(PERMISSIONS.DOCUMENT_VIEW, async ({ dbName, collectionName }) => {
+      const databaseInstance = await axioDBInstance.createDB(dbName);
+      const collection = await databaseInstance.createCollection(collectionName);
+      const result = await collection.totalDocuments();
+      return { statusCode: 200, message: 'OK', data: result.data };
+    }),
+  );
+
+  server.registerTool(
+    'axiodb_aggregate',
+    {
+      description: 'Run a MongoDB-style aggregation pipeline ($match, $group, $sort, etc.) against a collection.',
+      inputSchema: {
+        ...sessionIdField,
+        dbName: z.string().min(1),
+        collectionName: z.string().min(1),
+        aggregation: z.array(z.record(z.string(), z.any())).min(1),
+      },
+    },
+    withAuth(PERMISSIONS.DOCUMENT_AGGREGATE, ({ dbName, collectionName, aggregation }) =>
+      crudController.runAggregation({ query: { dbName, collectionName }, body: { aggregation } }),
+    ),
+  );
+};

--- a/Docker/mcp/tools/index.tools.js
+++ b/Docker/mcp/tools/index.tools.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { z } = require('zod');
+const IndexController = require('../../lib/server/controller/Index/Index.controller').default;
+const { PERMISSIONS } = require('../../lib/config/Keys/Permissions');
+const { sessionIdField, withAuth } = require('../shared.helpers');
+
+module.exports = function registerIndexTools(server, axioDBInstance) {
+  const indexController = new IndexController(axioDBInstance);
+
+  server.registerTool(
+    'axiodb_create_index',
+    {
+      description: 'Create an index on one or more fields of a collection.',
+      inputSchema: {
+        ...sessionIdField,
+        dbName: z.string().min(1),
+        collectionName: z.string().min(1),
+        fieldNames: z.array(z.string()).min(1),
+      },
+    },
+    withAuth(PERMISSIONS.INDEX_CREATE, ({ dbName, collectionName, fieldNames }) =>
+      indexController.createIndex({ body: { dbName, collectionName, fieldNames } }),
+    ),
+  );
+
+  server.registerTool(
+    'axiodb_drop_index',
+    {
+      description: 'Delete an index from a collection.',
+      inputSchema: {
+        ...sessionIdField,
+        dbName: z.string().min(1),
+        collectionName: z.string().min(1),
+        indexName: z.string().min(1),
+      },
+    },
+    withAuth(PERMISSIONS.INDEX_DELETE, ({ dbName, collectionName, indexName }) =>
+      indexController.deleteIndex({ query: { dbName, collectionName, indexName } }),
+    ),
+  );
+
+  server.registerTool(
+    'axiodb_list_indexes',
+    {
+      description: 'List the indexes defined on a collection.',
+      inputSchema: { ...sessionIdField, dbName: z.string().min(1), collectionName: z.string().min(1) },
+    },
+    withAuth(PERMISSIONS.INDEX_VIEW, ({ dbName, collectionName }) =>
+      indexController.getIndexes({ query: { dbName, collectionName } }),
+    ),
+  );
+};

--- a/Docker/mcp/tools/role.tools.js
+++ b/Docker/mcp/tools/role.tools.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const { z } = require('zod');
+const RoleManagementController = require('../../lib/server/controller/Auth/RoleManagement.controller').default;
+const { PERMISSIONS } = require('../../lib/config/Keys/Permissions');
+const { sessionIdField, NOOP_REPLY, withAuth } = require('../shared.helpers');
+
+module.exports = function registerRoleTools(server) {
+  server.registerTool(
+    'axiodb_list_roles',
+    {
+      description: '[Super Admin] List all roles and their permissions.',
+      inputSchema: { ...sessionIdField },
+    },
+    withAuth(PERMISSIONS.ROLE_VIEW, () =>
+      new RoleManagementController().listRoles({}, NOOP_REPLY),
+    ),
+  );
+
+  server.registerTool(
+    'axiodb_create_role',
+    {
+      description: '[Super Admin] Create a new role from the predefined permission catalogue.',
+      inputSchema: {
+        ...sessionIdField,
+        roleName: z.string().min(1),
+        permissions: z.array(z.string()).min(1),
+      },
+    },
+    withAuth(PERMISSIONS.ROLE_CREATE, ({ roleName, permissions }) =>
+      new RoleManagementController().createRole(
+        { body: { roleName, permissions } },
+        NOOP_REPLY,
+      ),
+    ),
+  );
+
+  server.registerTool(
+    'axiodb_delete_role',
+    {
+      description: '[Super Admin] Delete a custom role. Predefined system roles (Super Admin, Admin, View) and roles still assigned to a user cannot be deleted.',
+      inputSchema: { ...sessionIdField, roleName: z.string().min(1) },
+    },
+    withAuth(PERMISSIONS.ROLE_DELETE, ({ roleName }) =>
+      new RoleManagementController().deleteRole({ params: { roleName } }, NOOP_REPLY),
+    ),
+  );
+
+  server.registerTool(
+    'axiodb_list_permissions',
+    {
+      description: '[Super Admin] List the full permission catalogue available for custom roles.',
+      inputSchema: { ...sessionIdField },
+    },
+    withAuth(PERMISSIONS.ROLE_VIEW, () =>
+      new RoleManagementController().listPermissions({}, NOOP_REPLY),
+    ),
+  );
+};

--- a/Docker/mcp/tools/user.tools.js
+++ b/Docker/mcp/tools/user.tools.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const { z } = require('zod');
+const UserManagementController = require('../../lib/server/controller/Auth/UserManagement.controller').default;
+const { PERMISSIONS } = require('../../lib/config/Keys/Permissions');
+const { sessionIdField, NOOP_REPLY, withAuth } = require('../shared.helpers');
+
+module.exports = function registerUserTools(server) {
+  server.registerTool(
+    'axiodb_list_users',
+    {
+      description: '[Super Admin] List all RBAC users.',
+      inputSchema: { ...sessionIdField },
+    },
+    withAuth(PERMISSIONS.USER_VIEW, () =>
+      new UserManagementController().listUsers({}, NOOP_REPLY),
+    ),
+  );
+
+  server.registerTool(
+    'axiodb_create_user',
+    {
+      description: '[Super Admin] Create a new RBAC user with a given role.',
+      inputSchema: {
+        ...sessionIdField,
+        username: z.string().min(1),
+        password: z.string().min(4),
+        role: z.string().min(1),
+      },
+    },
+    withAuth(PERMISSIONS.USER_CREATE, ({ username, password, role }) =>
+      new UserManagementController().createUser(
+        { body: { username, password, role } },
+        NOOP_REPLY,
+      ),
+    ),
+  );
+
+  server.registerTool(
+    'axiodb_update_user_role',
+    {
+      description: "[Super Admin] Change a user's assigned role.",
+      inputSchema: { ...sessionIdField, username: z.string().min(1), role: z.string().min(1) },
+    },
+    withAuth(PERMISSIONS.USER_UPDATE_ROLE, ({ username, role }) =>
+      new UserManagementController().updateUserRole(
+        { params: { username }, body: { role } },
+        NOOP_REPLY,
+      ),
+    ),
+  );
+
+  server.registerTool(
+    'axiodb_reset_user_password',
+    {
+      description: "[Super Admin] Reset a user's password (forces them to change it on next login).",
+      inputSchema: { ...sessionIdField, username: z.string().min(1), newPassword: z.string().min(4) },
+    },
+    withAuth(PERMISSIONS.USER_RESET_PASSWORD, ({ username, newPassword }) =>
+      new UserManagementController().resetUserPassword(
+        { params: { username }, body: { newPassword } },
+        NOOP_REPLY,
+      ),
+    ),
+  );
+
+  server.registerTool(
+    'axiodb_delete_user',
+    {
+      description: '[Super Admin] Delete a user.',
+      inputSchema: { ...sessionIdField, username: z.string().min(1) },
+    },
+    withAuth(PERMISSIONS.USER_DELETE, ({ username }) =>
+      new UserManagementController().deleteUser({ params: { username } }, NOOP_REPLY),
+    ),
+  );
+};

--- a/Docker/mcpServer.js
+++ b/Docker/mcpServer.js
@@ -1,0 +1,109 @@
+'use strict';
+
+// MCP server for AxioDB's Docker deployment. Deliberately lives here (not in source/) and
+// is required only via relative `./lib/...` paths into the SAME compiled output the rest of
+// this image already ships - no extra `axiodb` package install, no second AxioDB instance.
+// It exposes the exact same data-plane + control-plane operations the HTTP GUI does, gated
+// by the exact same RBAC (login -> session -> PermissionChecker), just as MCP tools instead
+// of Fastify routes. Each feature area's tools live in mcp/tools/ (see architecture.md's
+// "feature-based, one responsibility per file" convention); this file only wires them up and
+// runs the Streamable HTTP transport.
+
+const http = require('http');
+const { randomUUID } = require('crypto');
+const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+
+const SessionStore = require('./lib/Services/Auth/SessionStore.service').default;
+const LoginRateLimiter = require('./lib/Services/Auth/LoginRateLimiter.service').default;
+
+const registerAuthTools = require('./mcp/tools/auth.tools');
+const registerDatabaseTools = require('./mcp/tools/database.tools');
+const registerCollectionTools = require('./mcp/tools/collection.tools');
+const registerDocumentTools = require('./mcp/tools/document.tools');
+const registerIndexTools = require('./mcp/tools/index.tools');
+const registerDashboardTools = require('./mcp/tools/dashboard.tools');
+const registerUserTools = require('./mcp/tools/user.tools');
+const registerRoleTools = require('./mcp/tools/role.tools');
+
+const MCP_SERVER_NAME = 'axiodb-mcp-server';
+const MCP_SERVER_VERSION = '1.0.0';
+
+function buildMcpServer(axioDBInstance) {
+  const server = new McpServer({ name: MCP_SERVER_NAME, version: MCP_SERVER_VERSION });
+  registerAuthTools(server, axioDBInstance);
+  registerDatabaseTools(server, axioDBInstance);
+  registerCollectionTools(server, axioDBInstance);
+  registerDocumentTools(server, axioDBInstance);
+  registerIndexTools(server, axioDBInstance);
+  registerDashboardTools(server, axioDBInstance);
+  registerUserTools(server, axioDBInstance);
+  registerRoleTools(server, axioDBInstance);
+  return server;
+}
+
+/**
+ * Starts the MCP server on its own HTTP port (Streamable HTTP transport, stateful: one
+ * McpServer+transport pair per MCP client session, tracked by the transport's own
+ * Mcp-Session-Id - distinct from the RBAC `sessionId` every tool call carries as an input).
+ */
+function startMcpServer(axioDBInstance, port) {
+  const transports = new Map();
+
+  const httpServer = http.createServer(async (req, res) => {
+    if (req.method !== 'POST' && req.method !== 'GET' && req.method !== 'DELETE') {
+      res.writeHead(405).end();
+      return;
+    }
+    if (!req.url || !req.url.startsWith('/mcp')) {
+      res.writeHead(404).end();
+      return;
+    }
+
+    const mcpSessionId = req.headers['mcp-session-id'];
+    let transport = typeof mcpSessionId === 'string' ? transports.get(mcpSessionId) : undefined;
+
+    if (!transport) {
+      if (req.method !== 'POST') {
+        res.writeHead(400).end('No active MCP session for this request');
+        return;
+      }
+      transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (sid) => transports.set(sid, transport),
+      });
+      transport.onclose = () => {
+        if (transport.sessionId) {
+          transports.delete(transport.sessionId);
+        }
+      };
+      buildMcpServer(axioDBInstance).connect(transport);
+    }
+
+    let parsedBody;
+    if (req.method === 'POST') {
+      const chunks = [];
+      for await (const chunk of req) {
+        chunks.push(chunk);
+      }
+      const raw = Buffer.concat(chunks).toString('utf8');
+      parsedBody = raw ? JSON.parse(raw) : undefined;
+    }
+
+    await transport.handleRequest(req, res, parsedBody);
+  });
+
+  SessionStore.startCleanupSweep();
+  LoginRateLimiter.startCleanupSweep();
+
+  httpServer.listen(port, () => {
+    console.log(`[AxioDB MCP] Streamable HTTP server listening on port ${port} (POST/GET/DELETE /mcp)`);
+  });
+
+  return httpServer;
+}
+
+module.exports = function mcpServerEntry(axioDBInstance) {
+  const port = parseInt(process.env.AXIODB_MCP_PORT || '27020', 10);
+  return startMcpServer(axioDBInstance, port);
+};

--- a/Docker/runner.js
+++ b/Docker/runner.js
@@ -31,4 +31,13 @@ if (process.env.AXIODB_TLS_KEY_PATH) {
   options.TLSKeyPath = process.env.AXIODB_TLS_KEY_PATH;
 }
 
-new AxioDB(options);
+const axioDBInstance = new AxioDB(options);
+
+// Opt-in MCP server (Model Context Protocol) - runs in this same process against this same
+// AxioDB instance, on its own port. Requires real login (default admin/admin, same as the
+// GUI) and enforces the same RBAC permissions per tool call; see mcpServer.js.
+if (parseBoolean(process.env.AXIODB_MCP, false)) {
+  require('./mcpServer.js')(axioDBInstance);
+}
+
+module.exports = axioDBInstance;

--- a/Document/public/llms.txt
+++ b/Document/public/llms.txt
@@ -45,6 +45,7 @@ Requires Node.js >= 20.0.0
 - [Create Collection](https://axiodb.in/create-collection)
 - [AxioDBCloud (Remote/TCP)](https://axiodb.in/cloud)
 - [Docker Deployment](https://axiodb.in/docker)
+- [MCP Server (AI Agent Integration)](https://axiodb.in/mcp-server)
 - [Troubleshooting](https://axiodb.in/troubleshooting)
 - [Changelog](https://axiodb.in/changelog)
 - [Maintainer's Zone](https://axiodb.in/maintainers-zone)

--- a/Document/public/sitemap.xml
+++ b/Document/public/sitemap.xml
@@ -91,6 +91,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://axiodb.in/mcp-server</loc>
+    <lastmod>2026-07-11</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://axiodb.in/troubleshooting</loc>
     <lastmod>2026-07-11</lastmod>
     <changefreq>monthly</changefreq>

--- a/Document/src/App.tsx
+++ b/Document/src/App.tsx
@@ -17,6 +17,7 @@ import CreateCollection from "./components/content/CreateCollection";
 import MaintainersZone from "./components/content/MaintainersZone";
 import AxioDBCloud from "./components/content/AxioDBCloud";
 import Docker from "./components/content/Docker";
+import McpServer from "./components/content/McpServer";
 import Troubleshooting from "./components/content/Troubleshooting";
 import Changelog from "./components/content/Changelog";
 
@@ -46,6 +47,7 @@ export const routes: RouteRecord[] = [
       { path: "create-collection", element: <CreateCollection /> },
       { path: "cloud", element: <AxioDBCloud /> },
       { path: "docker", element: <Docker /> },
+      { path: "mcp-server", element: <McpServer /> },
       { path: "troubleshooting", element: <Troubleshooting /> },
       { path: "changelog", element: <Changelog /> },
       { path: "maintainers-zone", element: <MaintainersZone /> },

--- a/Document/src/components/content/Introduction.tsx
+++ b/Document/src/components/content/Introduction.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowRight,
+  Bot,
   Cloud,
   Code,
   Database,
@@ -133,6 +134,32 @@ const Introduction: React.FC = () => {
               className="h-7 rounded shadow-sm hover:shadow-md transition-shadow"
             />
           </div>
+
+          {/* New Feature Banner: MCP Server */}
+          <a
+            href="/mcp-server"
+            className="group flex flex-col sm:flex-row items-start sm:items-center gap-4 bg-gradient-to-r from-fuchsia-100 via-purple-50 to-indigo-100 dark:from-fuchsia-900/40 dark:via-purple-900/30 dark:to-indigo-900/40 px-6 py-5 rounded-xl border-2 border-fuchsia-300 dark:border-fuchsia-600 shadow-xl hover:shadow-2xl transition-all duration-300 mb-8"
+          >
+            <div className="flex items-center justify-center w-12 h-12 bg-gradient-to-br from-fuchsia-500 to-purple-600 rounded-xl shadow-lg group-hover:scale-110 transition-transform duration-300 flex-shrink-0">
+              <Bot className="h-6 w-6 text-white" />
+            </div>
+            <div className="flex-1">
+              <div className="flex flex-wrap items-center gap-2 mb-1">
+                <span className="text-xs bg-gradient-to-r from-fuchsia-500 to-purple-600 text-white px-2.5 py-1 rounded-full font-bold shadow-md">
+                  NEW
+                </span>
+                <span className="text-lg font-black bg-gradient-to-r from-fuchsia-700 to-purple-700 dark:from-fuchsia-300 dark:to-purple-300 bg-clip-text text-transparent">
+                  AxioDB MCP Server
+                </span>
+              </div>
+              <p className="text-sm text-slate-700 dark:text-slate-300">
+                Spin up AxioDB on a cloud container and let your AI agent (Claude, or any
+                MCP-compatible client) talk to that database directly — 32 tools, real login,
+                the exact same RBAC as the web GUI.
+              </p>
+            </div>
+            <ArrowRight className="h-6 w-6 text-fuchsia-600 dark:text-fuchsia-400 flex-shrink-0 group-hover:translate-x-1 transition-transform duration-300" />
+          </a>
 
           {/* NPM Download Stats */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">

--- a/Document/src/components/content/McpServer.tsx
+++ b/Document/src/components/content/McpServer.tsx
@@ -1,0 +1,442 @@
+import React from "react";
+import Seo from "../ui/Seo";
+import CodeBlock from "../ui/CodeBlock";
+import {
+  Bot,
+  KeyRound,
+  ShieldCheck,
+  Terminal,
+  Database,
+  Layers,
+  Users,
+  ArrowRight,
+  ExternalLink,
+} from "lucide-react";
+
+const toolGroups: { title: string; permissionNote: string; tools: string[] }[] = [
+  {
+    title: "Session",
+    permissionNote: "No permission required — login is the gate itself",
+    tools: ["axiodb_login", "axiodb_logout", "axiodb_whoami", "axiodb_change_own_password"],
+  },
+  {
+    title: "Database",
+    permissionNote: "db:view / db:create / db:delete",
+    tools: [
+      "axiodb_create_database",
+      "axiodb_delete_database",
+      "axiodb_database_exists",
+      "axiodb_get_instance_info",
+    ],
+  },
+  {
+    title: "Collection",
+    permissionNote: "collection:view / collection:create / collection:delete",
+    tools: [
+      "axiodb_create_collection",
+      "axiodb_delete_collection",
+      "axiodb_collection_exists",
+      "axiodb_get_collection_info",
+    ],
+  },
+  {
+    title: "Documents & Aggregation",
+    permissionNote: "document:view / query / create / update / delete / aggregate",
+    tools: [
+      "axiodb_insert_document",
+      "axiodb_insert_many_documents",
+      "axiodb_query_documents",
+      "axiodb_update_document",
+      "axiodb_delete_document",
+      "axiodb_total_documents",
+      "axiodb_aggregate",
+    ],
+  },
+  {
+    title: "Index",
+    permissionNote: "index:view / index:create / index:delete",
+    tools: ["axiodb_create_index", "axiodb_drop_index", "axiodb_list_indexes"],
+  },
+  {
+    title: "Dashboard",
+    permissionNote: "dashboard:view",
+    tools: ["axiodb_get_dashboard_stats"],
+  },
+  {
+    title: "User Management",
+    permissionNote: "user:view / create / update-role / reset-password / delete — Super Admin role only",
+    tools: [
+      "axiodb_list_users",
+      "axiodb_create_user",
+      "axiodb_update_user_role",
+      "axiodb_reset_user_password",
+      "axiodb_delete_user",
+    ],
+  },
+  {
+    title: "Role Management",
+    permissionNote: "role:view / role:create / role:delete — Super Admin role only",
+    tools: ["axiodb_list_roles", "axiodb_create_role", "axiodb_delete_role", "axiodb_list_permissions"],
+  },
+];
+
+const McpServer: React.FC = () => {
+  return (
+    <div className="space-y-12">
+      <Seo
+        title="MCP Server | AxioDB Documentation"
+        description="Let AI agents (Claude, and any MCP-compatible client) talk to your AxioDB instance directly - 32 tools, real login, and the exact same RBAC as the web GUI."
+        path="/mcp-server"
+      />
+
+      {/* Hero Section */}
+      <section className="relative overflow-hidden bg-gradient-to-br from-fuchsia-50 via-white to-purple-50 dark:from-fuchsia-900/20 dark:via-slate-800 dark:to-purple-900/20 rounded-2xl p-8 lg:p-12 border border-fuchsia-200 dark:border-fuchsia-700 shadow-xl">
+        <div className="absolute top-0 right-0 w-64 h-64 bg-gradient-to-br from-fuchsia-400/10 to-purple-400/10 rounded-full blur-3xl"></div>
+        <div className="relative z-10">
+          <div className="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-fuchsia-100 to-purple-100 dark:from-fuchsia-900/40 dark:to-purple-900/40 rounded-full border border-fuchsia-300 dark:border-fuchsia-600 mb-6">
+            <Bot className="h-5 w-5 text-fuchsia-600 dark:text-fuchsia-400" />
+            <span className="text-fuchsia-700 dark:text-fuchsia-300 font-semibold">
+              AI AGENT INTEGRATION
+            </span>
+          </div>
+
+          <h1 className="text-5xl lg:text-6xl font-extrabold mb-6 bg-gradient-to-r from-fuchsia-600 via-purple-600 to-indigo-600 dark:from-fuchsia-400 dark:via-purple-400 dark:to-indigo-400 bg-clip-text text-transparent">
+            MCP Server
+          </h1>
+
+          <p className="text-lg text-slate-600 dark:text-slate-400 leading-relaxed max-w-3xl">
+            Spin up AxioDB in a container and let Claude (or any MCP-compatible AI agent) talk to
+            it directly — create databases, query documents, run aggregations, manage users and
+            roles, all through 32 tools that log in and enforce the exact same RBAC as the web
+            GUI. It runs in the same process as your existing Docker deployment — no separate
+            install, no new database instance.
+          </p>
+        </div>
+      </section>
+
+      {/* Quick Start */}
+      <section>
+        <h2 className="text-3xl font-bold mb-6 text-slate-900 dark:text-white flex items-center gap-3">
+          <Terminal className="h-8 w-8 text-fuchsia-500" />
+          Quick Start
+        </h2>
+
+        <div className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-slate-200 dark:border-slate-700 space-y-4">
+          <p className="text-slate-700 dark:text-slate-300">
+            The MCP server is <strong>opt-in</strong> and disabled by default — set{" "}
+            <code className="px-1.5 py-0.5 bg-slate-100 dark:bg-slate-900 rounded">AXIODB_MCP=true</code>{" "}
+            on the same container you already run for the GUI/TCP server:
+          </p>
+          <CodeBlock
+            language="bash"
+            code={`docker run -d \\
+  --name axiodb-server \\
+  -e AXIODB_GUI=true \\
+  -e AXIODB_MCP=true \\
+  -p 27018:27018 \\
+  -p 27019:27019 \\
+  -p 27020:27020 \\
+  -v axiodb-data:/app \\
+  theankansaha/axiodb
+
+# Ports:
+# 27018 - HTTP GUI Dashboard
+# 27019 - TCP Remote Access (AxioDBCloud)
+# 27020 - MCP Server (Streamable HTTP, path /mcp)`}
+          />
+
+          <p className="text-slate-700 dark:text-slate-300">
+            Register the endpoint (<code className="px-1 py-0.5 bg-slate-100 dark:bg-slate-900 rounded">http://localhost:27020/mcp</code>) with whichever AI tool you use:
+          </p>
+
+          <div className="space-y-4">
+            <div>
+              <h4 className="font-semibold text-slate-900 dark:text-white mb-2">Claude Code</h4>
+              <CodeBlock
+                language="bash"
+                code={`claude mcp add --transport http axiodb http://localhost:27020/mcp
+
+# Available across every project instead of just this one:
+claude mcp add --transport http axiodb http://localhost:27020/mcp -s user`}
+              />
+            </div>
+
+            <div>
+              <h4 className="font-semibold text-slate-900 dark:text-white mb-2">OpenAI Codex CLI</h4>
+              <CodeBlock
+                language="bash"
+                code={`codex mcp add axiodb --url http://localhost:27020/mcp
+
+# Or edit ~/.codex/config.toml directly:
+[mcp_servers.axiodb]
+url = "http://localhost:27020/mcp"`}
+              />
+            </div>
+
+            <div>
+              <h4 className="font-semibold text-slate-900 dark:text-white mb-2">opencode</h4>
+              <CodeBlock
+                language="bash"
+                code={`opencode mcp add
+# Interactive prompt: choose "remote", name it "axiodb",
+# URL: http://localhost:27020/mcp
+
+# Or edit opencode.json directly:
+{
+  "mcp": {
+    "axiodb": {
+      "type": "remote",
+      "url": "http://localhost:27020/mcp",
+      "enabled": true
+    }
+  }
+}`}
+              />
+            </div>
+
+            <div>
+              <h4 className="font-semibold text-slate-900 dark:text-white mb-2">GitHub Copilot CLI</h4>
+              <CodeBlock
+                language="bash"
+                code={`# Interactive: run copilot, then inside it type:
+/mcp add
+# Server Name: axiodb | Type: HTTP | URL: http://localhost:27020/mcp
+
+# Or edit ~/.copilot/mcp-config.json directly:
+{
+  "mcpServers": {
+    "axiodb": {
+      "type": "http",
+      "url": "http://localhost:27020/mcp"
+    }
+  }
+}`}
+              />
+            </div>
+
+            <div>
+              <h4 className="font-semibold text-slate-900 dark:text-white mb-2">Cursor</h4>
+              <CodeBlock
+                language="json"
+                code={`// .cursor/mcp.json (project) or ~/.cursor/mcp.json (global)
+{
+  "mcpServers": {
+    "axiodb": {
+      "url": "http://localhost:27020/mcp"
+    }
+  }
+}`}
+              />
+            </div>
+
+            <div>
+              <h4 className="font-semibold text-slate-900 dark:text-white mb-2">Windsurf</h4>
+              <CodeBlock
+                language="json"
+                code={`// ~/.codeium/windsurf/mcp_config.json
+{
+  "mcpServers": {
+    "axiodb": {
+      "serverUrl": "http://localhost:27020/mcp"
+    }
+  }
+}`}
+              />
+            </div>
+
+            <div>
+              <h4 className="font-semibold text-slate-900 dark:text-white mb-2">Google Antigravity (IDE &amp; CLI)</h4>
+              <CodeBlock
+                language="json"
+                code={`// ~/.gemini/config/mcp_config.json - note: serverUrl, not url
+{
+  "mcpServers": {
+    "axiodb": {
+      "serverUrl": "http://localhost:27020/mcp"
+    }
+  }
+}`}
+              />
+            </div>
+          </div>
+
+          <div className="p-4 bg-fuchsia-50 dark:bg-fuchsia-900/20 rounded-lg border border-fuchsia-200 dark:border-fuchsia-700">
+            <p className="text-sm text-fuchsia-800 dark:text-fuchsia-200">
+              <strong>AXIODB_MCP=true</strong> only has something to serve once RBAC is actually
+              seeded — that requires <code className="px-1 py-0.5 bg-white dark:bg-slate-800 rounded">AXIODB_GUI=true</code>{" "}
+              (the default) or <code className="px-1 py-0.5 bg-white dark:bg-slate-800 rounded">AXIODB_TCP=true</code> +{" "}
+              <code className="px-1 py-0.5 bg-white dark:bg-slate-800 rounded">AXIODB_TCP_AUTH=true</code>. See{" "}
+              <a href="/docker" className="underline font-medium">Docker Deployment</a> for every environment variable.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Real login, real RBAC */}
+      <section>
+        <h2 className="text-3xl font-bold mb-6 text-slate-900 dark:text-white flex items-center gap-3">
+          <KeyRound className="h-8 w-8 text-purple-500" />
+          Real Login, Real RBAC — Not a Docker Env Var
+        </h2>
+
+        <div className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-slate-200 dark:border-slate-700 space-y-4">
+          <p className="text-slate-700 dark:text-slate-300">
+            Every tool except <code className="px-1.5 py-0.5 bg-slate-100 dark:bg-slate-900 rounded">axiodb_login</code>{" "}
+            requires a <code className="px-1.5 py-0.5 bg-slate-100 dark:bg-slate-900 rounded">sessionId</code>. Call{" "}
+            <code className="px-1.5 py-0.5 bg-slate-100 dark:bg-slate-900 rounded">axiodb_login</code> first with the
+            seeded default account (<code className="px-1 py-0.5 bg-slate-100 dark:bg-slate-900 rounded">admin</code>/
+            <code className="px-1 py-0.5 bg-slate-100 dark:bg-slate-900 rounded">admin</code>, same as the GUI) or any
+            other RBAC user, and every subsequent call is checked against{" "}
+            <em>that logged-in user&apos;s actual role</em> — a View-role session gets a real 403 on
+            write tools, exactly like the GUI would. Nothing is gated by a static container
+            environment variable.
+          </p>
+          <CodeBlock
+            language="json"
+            code={`// axiodb_login({ username: "admin", password: "admin" })
+{
+  "statusCode": 200,
+  "message": "Login successful",
+  "data": {
+    "sessionId": "a1b2c3...",
+    "username": "admin",
+    "role": "Super Admin",
+    "permissions": ["db:view", "db:create", "..."],
+    "mustChangePassword": true
+  }
+}`}
+          />
+          <ul className="list-disc list-inside text-slate-700 dark:text-slate-300 space-y-1">
+            <li>Sessions live in server memory only, 24h sliding TTL — call <code className="px-1 py-0.5 bg-slate-100 dark:bg-slate-900 rounded">axiodb_logout</code> when done rather than waiting it out</li>
+            <li><code className="px-1 py-0.5 bg-slate-100 dark:bg-slate-900 rounded">axiodb_whoami</code> returns the identity/role/permissions behind a given session</li>
+            <li><code className="px-1 py-0.5 bg-slate-100 dark:bg-slate-900 rounded">axiodb_change_own_password</code> rotates the session and returns a new <code className="px-1 py-0.5 bg-slate-100 dark:bg-slate-900 rounded">sessionId</code></li>
+            <li>Same login rate limiter as the GUI/TCP login (5 failed attempts / 15 min lockout)</li>
+          </ul>
+        </div>
+      </section>
+
+      {/* Tool catalogue */}
+      <section>
+        <h2 className="text-3xl font-bold mb-6 text-slate-900 dark:text-white flex items-center gap-3">
+          <Layers className="h-8 w-8 text-indigo-500" />
+          32 Tools, Mirroring the HTTP Control Server 1:1
+        </h2>
+        <p className="text-slate-700 dark:text-slate-300 mb-6 max-w-3xl">
+          Every MCP tool maps to the exact same controller and permission check as its HTTP
+          route counterpart — nothing was reimplemented, so behavior (validation, error
+          messages, RBAC) never drifts between the GUI and the MCP surface.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {toolGroups.map((group) => (
+            <div
+              key={group.title}
+              className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-slate-200 dark:border-slate-700"
+            >
+              <h3 className="text-lg font-bold text-slate-900 dark:text-white mb-1">
+                {group.title}
+              </h3>
+              <p className="text-xs text-slate-500 dark:text-slate-400 mb-3 font-mono">
+                {group.permissionNote}
+              </p>
+              <ul className="space-y-1">
+                {group.tools.map((tool) => (
+                  <li key={tool} className="text-sm font-mono text-slate-700 dark:text-slate-300">
+                    {tool}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-6 p-4 bg-slate-50 dark:bg-slate-900/40 rounded-lg border border-slate-200 dark:border-slate-700">
+          <p className="text-sm text-slate-600 dark:text-slate-400">
+            <strong>Out of scope by design:</strong> transactions and database export/import are
+            not exposed as MCP tools — kept out of this surface entirely rather than deferred.
+          </p>
+        </div>
+      </section>
+
+      {/* Example */}
+      <section>
+        <h2 className="text-3xl font-bold mb-6 text-slate-900 dark:text-white flex items-center gap-3">
+          <Database className="h-8 w-8 text-blue-500" />
+          Example: Insert &amp; Query From an Agent
+        </h2>
+        <div className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-slate-200 dark:border-slate-700">
+          <CodeBlock
+            language="text"
+            code={`1. axiodb_login({ username: "admin", password: "admin" })
+   -> sessionId: "a1b2c3..."
+
+2. axiodb_create_database({ sessionId, name: "shop" })
+
+3. axiodb_create_collection({ sessionId, dbName: "shop", collectionName: "orders" })
+
+4. axiodb_insert_document({
+     sessionId, dbName: "shop", collectionName: "orders",
+     document: { customer: "Alice", total: 49.99, status: "paid" }
+   })
+
+5. axiodb_query_documents({
+     sessionId, dbName: "shop", collectionName: "orders",
+     query: { status: "paid" }
+   })`}
+          />
+        </div>
+      </section>
+
+      {/* Security notes */}
+      <section>
+        <h2 className="text-3xl font-bold mb-6 text-slate-900 dark:text-white flex items-center gap-3">
+          <ShieldCheck className="h-8 w-8 text-emerald-500" />
+          Security Notes
+        </h2>
+        <div className="bg-white dark:bg-slate-800 p-6 rounded-xl border border-slate-200 dark:border-slate-700">
+          <ul className="list-disc list-inside text-slate-700 dark:text-slate-300 space-y-2">
+            <li>Every write/read tool is permission-checked against the caller&apos;s actual role on every call, not just at login</li>
+            <li>An invalid, expired, or missing <code className="px-1 py-0.5 bg-slate-100 dark:bg-slate-900 rounded">sessionId</code> is rejected before it ever reaches a database operation</li>
+            <li>Collection metadata responses (<code className="px-1 py-0.5 bg-slate-100 dark:bg-slate-900 rounded">axiodb_get_collection_info</code>) never include the raw AES encryption key — only whether a collection is encrypted</li>
+            <li>Expose port 27020 only to trusted networks/agents, same guidance as the TCP port — the MCP server carries the same authority as the GUI, just a different transport</li>
+          </ul>
+        </div>
+      </section>
+
+      {/* Next Steps */}
+      <section className="bg-gradient-to-r from-fuchsia-600 to-purple-600 text-white p-8 rounded-xl">
+        <h2 className="text-3xl font-bold mb-4">Give Your Agent a Database</h2>
+        <p className="text-xl mb-6 text-fuchsia-100">
+          Deploy the container, enable AXIODB_MCP, and register it with your MCP client.
+        </p>
+        <div className="flex flex-wrap gap-4">
+          <a
+            href="/docker"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-white text-fuchsia-600 rounded-lg font-semibold hover:bg-fuchsia-50 transition-colors"
+          >
+            Docker Deployment
+            <ArrowRight className="h-5 w-5" />
+          </a>
+          <a
+            href="https://github.com/nexoral/AxioDB/blob/main/Docker/README.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 px-6 py-3 border-2 border-white text-white rounded-lg font-semibold hover:bg-white/10 transition-colors"
+          >
+            Docker/README.md
+            <ExternalLink className="h-5 w-5" />
+          </a>
+          <a
+            href="/security"
+            className="inline-flex items-center gap-2 px-6 py-3 border-2 border-white text-white rounded-lg font-semibold hover:bg-white/10 transition-colors"
+          >
+            Security &amp; RBAC
+            <Users className="h-5 w-5" />
+          </a>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default McpServer;

--- a/Document/src/components/layout/Sidebar.tsx
+++ b/Document/src/components/layout/Sidebar.tsx
@@ -73,6 +73,10 @@ const sidebarSections: SidebarSection[] = [
     items: [{ id: "docker", label: "Docker Deployment", path: "/docker" }],
   },
   {
+    title: "AI Agent Integration",
+    items: [{ id: "mcp-server", label: "MCP Server", path: "/mcp-server" }],
+  },
+  {
     title: "API Reference",
     items: [
       { id: "api-reference", label: "SDK API Reference", path: "/api-reference" },

--- a/Document/src/data/changelog.ts
+++ b/Document/src/data/changelog.ts
@@ -12,6 +12,22 @@ export interface ChangelogEntry {
  */
 export const changelog: ChangelogEntry[] = [
   {
+    version: "12.10.20+",
+    date: "2026-07-12",
+    title: "MCP Server for AI agent integration",
+    changes: [
+      "MCP server (Model Context Protocol) added to the Docker image, opt-in via AXIODB_MCP=true, exposing 32 tools over Streamable HTTP on port 27020",
+      "Real login required (axiodb_login) - every tool is gated by the logged-in user's actual RBAC role, mirroring the HTTP Control Server's permissions exactly",
+      "Full coverage: database/collection/document CRUD, aggregation, indexes, dashboard stats, and user/role management (including a new role-deletion capability, added to both the HTTP API and MCP)",
+      "Session tools: axiodb_logout, axiodb_whoami, axiodb_change_own_password",
+      "Fixed: aggregation $sum/$avg crashing on numeric literal operands (e.g. { $sum: 1 })",
+      "Fixed: delete-by-query silently deleting nothing while reporting success when isMany was left unset",
+      "Fixed: total document count including the collection's internal indexes folder in the total",
+      "Fixed: collection metadata responses no longer leak the raw AES encryption key",
+      "Removed dead chmod-based file/directory locking code (LockFile/UnlockFile/IsFileLocked, LockDirectory/IsDirectoryLocked) that was never actually engaged by any internal flow",
+    ],
+  },
+  {
     version: "11.9.13+",
     date: "2026-07-11",
     title: "AxioDBCloud connection pooling, rate limiting & TLS",

--- a/Document/src/routeMeta.ts
+++ b/Document/src/routeMeta.ts
@@ -31,6 +31,7 @@ export const routeMeta: RouteMeta[] = [
   { path: "/create-collection", label: "Create Collection" },
   { path: "/cloud", label: "AxioDBCloud (Remote/TCP)" },
   { path: "/docker", label: "Docker Deployment" },
+  { path: "/mcp-server", label: "MCP Server (AI Agent Integration)" },
   { path: "/troubleshooting", label: "Troubleshooting" },
   { path: "/changelog", label: "Changelog" },
   { path: "/maintainers-zone", label: "Maintainer's Zone" },

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - [Docker Deployment](#-docker-deployment)
   - [Simple: run the container](#simple-run-the-container)
   - [Advanced: env vars, volumes, Compose](#advanced-env-vars-volumes-compose)
+- [MCP Server — AI Agent Integration](#-mcp-server--ai-agent-integration)
 - [Built-in Web GUI & Authentication (RBAC)](#-built-in-web-gui--authentication-rbac)
 - [Detailed Usage](#-detailed-usage)
 - [API Reference](#-api-reference)
@@ -471,6 +472,8 @@ Every option below has a default matching the image's previous fixed behavior �
 | `AXIODB_TLS_KEY_PATH` | *(none)* | Path **inside the container** to the matching PEM private key - required when `AXIODB_TLS=true` |
 | `AXIODB_ROOT_NAME` | `AxioDB` | Name of the root database folder created under the data volume |
 | `AXIODB_CUSTOM_PATH` | *(container's working directory)* | Custom path for database storage inside the container |
+| `AXIODB_MCP` | `false` | Enable the MCP server (AI agent integration) on port 27020 - see [MCP Server](#-mcp-server--ai-agent-integration) |
+| `AXIODB_MCP_PORT` | `27020` | Port the MCP server listens on inside the container |
 
 > Ports themselves (27018/27019) aren't configurable via environment variable — remap them at the Docker layer with `-p <host-port>:27018` / `-p <host-port>:27019`.
 
@@ -538,6 +541,50 @@ volumes:
 ```
 
 **Building the image from source, and a fuller Docker troubleshooting guide** (container won't start, port-in-use, data-persistence checks) live in [`Docker/README.md`](Docker/README.md) — the canonical Docker doc, not duplicated here in full.
+
+---
+
+## 🤖 MCP Server — AI Agent Integration
+
+Spin up the same Docker container with `AXIODB_MCP=true` and let Claude (or any MCP-compatible
+AI agent) talk to your AxioDB instance directly — 32 tools covering databases, collections,
+documents, aggregation, indexes, dashboard stats, and user/role management, all gated by the
+same RBAC as the web GUI. It runs in the same process as your existing container; nothing new
+to install, no second database instance.
+
+```bash
+docker run -d \
+  --name axiodb-server \
+  -e AXIODB_GUI=true \
+  -e AXIODB_MCP=true \
+  -p 27018:27018 \
+  -p 27019:27019 \
+  -p 27020:27020 \
+  -v axiodb-data:/app \
+  theankansaha/axiodb
+```
+
+Register the endpoint (`http://localhost:27020/mcp`) with whichever AI tool you use:
+
+| Tool | How |
+| --- | --- |
+| **Claude Code** | `claude mcp add --transport http axiodb http://localhost:27020/mcp` |
+| **OpenAI Codex CLI** | `codex mcp add axiodb --url http://localhost:27020/mcp` (or `[mcp_servers.axiodb]` + `url = "..."` in `~/.codex/config.toml`) |
+| **opencode** | `opencode mcp add` (interactive → type "remote") or add `"axiodb": { "type": "remote", "url": "...", "enabled": true }` under `mcp` in `opencode.json` |
+| **GitHub Copilot CLI** | `/mcp add` inside the `copilot` REPL, or add to `~/.copilot/mcp-config.json`: `{ "mcpServers": { "axiodb": { "type": "http", "url": "..." } } }` |
+| **Cursor** | Add to `.cursor/mcp.json` (or `~/.cursor/mcp.json`): `{ "mcpServers": { "axiodb": { "url": "..." } } }` |
+| **Windsurf** | Add to `~/.codeium/windsurf/mcp_config.json`: `{ "mcpServers": { "axiodb": { "serverUrl": "..." } } }` |
+| **Google Antigravity** (IDE & CLI) | Add to `~/.gemini/config/mcp_config.json`: `{ "mcpServers": { "axiodb": { "serverUrl": "..." } } }` — note `serverUrl`, not `url` |
+
+Every tool except `axiodb_login` requires a `sessionId` obtained by logging in first (default
+seeded account: `admin`/`admin`, same as the GUI) — every subsequent call is checked against
+that logged-in user's actual role, exactly like the HTTP Control Server. A View-role session
+gets a real `403` on write tools; nothing is gated by a static container environment variable.
+
+`AXIODB_MCP=true` only has RBAC to serve once it's actually seeded, which requires
+`AXIODB_GUI=true` (the default) or `AXIODB_TCP=true` + `AXIODB_TCP_AUTH=true`.
+
+Full tool catalogue, examples, and security notes: **[MCP Server docs](https://axiodb.in/mcp-server)**.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "12.10.20",
+  "version": "12.10.21",
   "description": "The Pure JavaScript Alternative to SQLite. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/source/Services/Aggregation/Aggregation.Operation.ts
+++ b/source/Services/Aggregation/Aggregation.Operation.ts
@@ -212,19 +212,22 @@ export default class Aggregation {
             any,
           ][]) {
             if (key === "_id") continue;
-            if (operation.$avg) {
-              const field = operation.$avg.replace("$", "");
+            if (operation.$avg !== undefined) {
+              const operand = operation.$avg;
+              const value =
+                typeof operand === "string" ? item[operand.replace("$", "")] : operand;
               groupedData[groupKey][key] = groupedData[groupKey][key] || {
                 sum: 0,
                 count: 0,
               };
-              groupedData[groupKey][key].sum += item[field];
+              groupedData[groupKey][key].sum += value;
               groupedData[groupKey][key].count += 1;
             }
-            if (operation.$sum) {
-              const field = operation.$sum.replace("$", "");
-              groupedData[groupKey][key] =
-                (groupedData[groupKey][key] || 0) + item[field];
+            if (operation.$sum !== undefined) {
+              const operand = operation.$sum;
+              const value =
+                typeof operand === "string" ? item[operand.replace("$", "")] : operand;
+              groupedData[groupKey][key] = (groupedData[groupKey][key] || 0) + value;
             }
           }
         }

--- a/source/Services/Auth/AuthService.service.ts
+++ b/source/Services/Auth/AuthService.service.ts
@@ -232,6 +232,37 @@ export default class AuthService {
     return result.data.documents as RoleDocument[];
   }
 
+  public async deleteRole(roleName: string): Promise<MutationResult> {
+    const roles = await this.listRoles();
+    const role = roles.find((entry) => entry.roleName === roleName);
+    if (!role) {
+      return { success: false, message: "Role not found" };
+    }
+    if (role.isSystemRole) {
+      return { success: false, message: "Cannot delete a predefined system role" };
+    }
+
+    const usersWithRole = await ConfigDatabase.getUsersCollection()
+      .query({ role: roleName })
+      .Limit(1)
+      .exec();
+    const hasUsers =
+      "data" in usersWithRole &&
+      Array.isArray(usersWithRole.data?.documents) &&
+      usersWithRole.data.documents.length > 0;
+    if (hasUsers) {
+      return {
+        success: false,
+        message: `Cannot delete role "${roleName}" - it is still assigned to one or more users`,
+      };
+    }
+
+    await ConfigDatabase.getRolesCollection().delete({ roleName }).deleteOne();
+    PermissionChecker.deleteRole(roleName);
+
+    return { success: true, message: "Role deleted successfully" };
+  }
+
   /**
    * Rejects an operation that would leave zero active Super Admin users behind,
    * preventing a permanent RBAC lockout.

--- a/source/Services/Auth/PermissionChecker.helper.ts
+++ b/source/Services/Auth/PermissionChecker.helper.ts
@@ -18,6 +18,10 @@ class PermissionChecker {
     this.rolePermissions.set(roleName, permissions);
   }
 
+  public deleteRole(roleName: string): void {
+    this.rolePermissions.delete(roleName);
+  }
+
   public hydrate(roles: { roleName: string; permissions: string[] }[]): void {
     for (const role of roles) {
       this.rolePermissions.set(role.roleName, role.permissions);

--- a/source/Services/CRUD Operation/Delete.operation.ts
+++ b/source/Services/CRUD Operation/Delete.operation.ts
@@ -293,9 +293,6 @@ export default class DeleteOperation {
   /**
    * Deletes a file from the specified path.
    *
-   * This method checks if the directory is locked before attempting to delete the file.
-   * If the directory is locked, it tries to unlock it, delete the file, and then lock it again.
-   *
    * @param fileName - The name of the file to be deleted
    * @returns A response object indicating success or failure
    *          Success response: { status: true, message: "File deleted successfully" }
@@ -303,7 +300,6 @@ export default class DeleteOperation {
    * @private
    */
   private async deleteFile(fileName: string) {
-    // Use FileManager's DeleteFileWithLock method for proper lock management
     return await this.fileManager.DeleteFileWithLock(this.path, fileName);
   }
 

--- a/source/Services/CRUD Operation/Update.operation.ts
+++ b/source/Services/CRUD Operation/Update.operation.ts
@@ -383,9 +383,6 @@ export default class UpdateOperation {
   /**
    * Deletes a file from the specified path.
    *
-   * This method checks if the directory is locked before attempting to delete the file.
-   * If the directory is locked, it tries to unlock it, delete the file, and then lock it again.
-   *
    * @param fileName - The name of the file to be deleted
    * @returns A response object indicating success or failure
    *          Success response: { status: true, message: "File deleted successfully" }
@@ -393,7 +390,6 @@ export default class UpdateOperation {
    * @private
    */
   private async deleteFileUpdate(fileName: string) {
-    // Use FileManager's DeleteFileWithLock method for proper lock management
     return await this.fileManager.DeleteFileWithLock(this.path, fileName);
   }
 

--- a/source/Services/Collection/collection.operation.ts
+++ b/source/Services/Collection/collection.operation.ts
@@ -87,49 +87,15 @@ export default class Collection {
     }
 
     try {
-      // Check if Directory Locked or not
-      const isLocked = await new FolderManager().IsDirectoryLocked(this.path);
-      if ("data" in isLocked) {
-        if (isLocked.data === false) {
-          // List all files in the directory
-          const files = await new FolderManager().ListDirectory(this.path);
-          const documentFiles = files.data.filter((fileName: string) =>
-            fileName.endsWith(General.DBMS_File_EXT),
-          );
-          return new ResponseHelper().Success({
-            message: "Total Documents in the Collection",
-            total: documentFiles.length,
-          });
-        } else {
-          // if Directory is locked then unlock it
-          const unlockResponse = await new FolderManager().UnlockDirectory(
-            this.path,
-          );
-          if ("data" in unlockResponse) {
-            // List all files in the directory
-            const files = await new FolderManager().ListDirectory(this.path);
-            const documentFiles = files.data.filter((fileName: string) =>
-              fileName.endsWith(General.DBMS_File_EXT),
-            );
-            // Lock the directory again
-            const lockResponse = await new FolderManager().LockDirectory(
-              this.path,
-            );
-            if ("data" in lockResponse) {
-              return new ResponseHelper().Success({
-                message: "Total Documents in the Collection",
-                total: documentFiles.length,
-              });
-            } else {
-              return new ResponseHelper().Error("Cannot lock the directory");
-            }
-          } else {
-            return new ResponseHelper().Error("Cannot unlock the directory");
-          }
-        }
-      } else {
-        return new ResponseHelper().Error("Cannot access the directory");
-      }
+      // List all files in the directory
+      const files = await new FolderManager().ListDirectory(this.path);
+      const documentFiles = files.data.filter((fileName: string) =>
+        fileName.endsWith(General.DBMS_File_EXT),
+      );
+      return new ResponseHelper().Success({
+        message: "Total Documents in the Collection",
+        total: documentFiles.length,
+      });
     } catch (error) {
       return new ResponseHelper().Error(error);
     }

--- a/source/Services/Collection/collection.operation.ts
+++ b/source/Services/Collection/collection.operation.ts
@@ -16,6 +16,7 @@ import Session from "../Transaction/Session.service";
 
 import { StatusCodes } from "../../config/Keys/StatusCode";
 import { CryptoHelper } from "../../Helper/Crypto.helper";
+import { General } from "../../config/Keys/Keys";
 
 // Converter
 import Converter from "../../Helper/Converter.helper";
@@ -92,9 +93,12 @@ export default class Collection {
         if (isLocked.data === false) {
           // List all files in the directory
           const files = await new FolderManager().ListDirectory(this.path);
+          const documentFiles = files.data.filter((fileName: string) =>
+            fileName.endsWith(General.DBMS_File_EXT),
+          );
           return new ResponseHelper().Success({
             message: "Total Documents in the Collection",
-            total: files.data.length,
+            total: documentFiles.length,
           });
         } else {
           // if Directory is locked then unlock it
@@ -104,6 +108,9 @@ export default class Collection {
           if ("data" in unlockResponse) {
             // List all files in the directory
             const files = await new FolderManager().ListDirectory(this.path);
+            const documentFiles = files.data.filter((fileName: string) =>
+              fileName.endsWith(General.DBMS_File_EXT),
+            );
             // Lock the directory again
             const lockResponse = await new FolderManager().LockDirectory(
               this.path,
@@ -111,7 +118,7 @@ export default class Collection {
             if ("data" in lockResponse) {
               return new ResponseHelper().Success({
                 message: "Total Documents in the Collection",
-                total: files.data.length,
+                total: documentFiles.length,
               });
             } else {
               return new ResponseHelper().Error("Cannot lock the directory");

--- a/source/Services/Database/database.operation.ts
+++ b/source/Services/Database/database.operation.ts
@@ -178,6 +178,17 @@ export default class Database {
       ),
     );
 
+    // Never surface the raw encryption key outside the engine - getCollectionMetaDetails()
+    // itself must keep returning it (createCollection() needs the real key to re-open an
+    // existing encrypted collection), this response is the only place it gets redacted.
+    const RedactedCollectionStatus = CollectionStatus.map((meta) => {
+      if (!meta) {
+        return meta;
+      }
+      const { encryptionKey: _encryptionKey, ...safeMeta } = meta;
+      return safeMeta;
+    });
+
     if ("data" in collections && "data" in totalSize) {
       const FinalCollections: FinalCollectionsInfo = {
         CurrentPath: this.path,
@@ -186,7 +197,7 @@ export default class Database {
         TotalCollections: `${collections.data.length} Collections`,
         TotalSize: parseInt((totalSize.data / 1024 / 1024).toFixed(4)),
         ListOfCollections: collections.data,
-        collectionMetaStatus: CollectionStatus,
+        collectionMetaStatus: RedactedCollectionStatus,
         AllCollectionsPaths: collections.data.map((collection: string) =>
           path.join(this.path, collection),
         ),

--- a/source/Services/Index/Index.service.ts
+++ b/source/Services/Index/Index.service.ts
@@ -107,7 +107,16 @@ export class IndexManager {
         }
       }
     }
-    return this.ResponseHelper.Success(`Indexes: ${EffectedIndexes.join(", ")} created Indexes: ${FailedIndexes.join(", ")}`);
+    const messageParts: string[] = [];
+    if (EffectedIndexes.length > 0) {
+      messageParts.push(`Indexes created: ${EffectedIndexes.join(", ")}`);
+    }
+    if (FailedIndexes.length > 0) {
+      messageParts.push(`Indexes already existed: ${FailedIndexes.join(", ")}`);
+    }
+    return this.ResponseHelper.Success(
+      messageParts.length > 0 ? messageParts.join("; ") : "No new indexes created",
+    );
   }
 
   /**

--- a/source/config/Keys/Permissions.ts
+++ b/source/config/Keys/Permissions.ts
@@ -28,6 +28,7 @@ export const PERMISSIONS = {
 
   ROLE_VIEW: "role:view",
   ROLE_CREATE: "role:create",
+  ROLE_DELETE: "role:delete",
 
   INDEX_VIEW: "index:view",
   INDEX_CREATE: "index:create",
@@ -70,6 +71,7 @@ export const PERMISSION_CATALOGUE: PermissionCatalogueEntry[] = [
 
   { key: PERMISSIONS.ROLE_VIEW, group: "Role Management", description: "View the list of roles and the permission catalogue" },
   { key: PERMISSIONS.ROLE_CREATE, group: "Role Management", description: "Create new roles from the predefined permission catalogue" },
+  { key: PERMISSIONS.ROLE_DELETE, group: "Role Management", description: "Delete a custom role that is not a predefined system role and has no users assigned" },
 
   { key: PERMISSIONS.INDEX_VIEW, group: "Index", description: "View the list of indexes on a collection" },
   { key: PERMISSIONS.INDEX_CREATE, group: "Index", description: "Create new indexes on a collection" },

--- a/source/engine/Filesystem/FileManager.ts
+++ b/source/engine/Filesystem/FileManager.ts
@@ -6,7 +6,6 @@ import {
   SuccessInterface,
 } from "../../config/Interfaces/Helper/response.helper.interface";
 import WorkerProcess from "../cli/worker_process";
-import FolderManager from "./FolderManager";
 
 export default class FileManager {
   private readonly responseHelper: ResponseHelper;
@@ -68,29 +67,6 @@ export default class FileManager {
     return await this.WriteFile(path, "");
   }
 
-  /** "Locked" means chmod 0o400 (read-only for the owner). */
-  public async LockFile(
-    path: string,
-  ): Promise<SuccessInterface | ErrorInterface> {
-    try {
-      await fs.chmod(path, 0o400);
-      return this.responseHelper.Success("File locked successfully.");
-    } catch (error) {
-      return this.responseHelper.Error(error);
-    }
-  }
-
-  public async UnlockFile(
-    path: string,
-  ): Promise<SuccessInterface | ErrorInterface> {
-    try {
-      await fs.chmod(path, 0o777);
-      return this.responseHelper.Success("File unlocked successfully.");
-    } catch (error) {
-      return this.responseHelper.Error(error);
-    }
-  }
-
   public async MoveFile(
     oldPath: string,
     newPath: string,
@@ -98,18 +74,6 @@ export default class FileManager {
     try {
       await fs.rename(oldPath, newPath);
       return this.responseHelper.Success("File moved successfully.");
-    } catch (error) {
-      return this.responseHelper.Error(error);
-    }
-  }
-
-  /** A file is considered locked if its permissions are read-only for the owner (mode 0o400). */
-  public async IsFileLocked(
-    path: string,
-  ): Promise<SuccessInterface | ErrorInterface> {
-    try {
-      const stats = await fs.stat(path);
-      return this.responseHelper.Success((stats.mode & 0o777) === 0o400);
     } catch (error) {
       return this.responseHelper.Error(error);
     }
@@ -199,52 +163,14 @@ export default class FileManager {
     }
   }
 
-  /**
-   * Handles file deletion with proper directory lock/unlock sequences: if the directory is
-   * unlocked, deletes the file directly; if locked, unlocks, deletes, then relocks it.
-   */
   public async DeleteFileWithLock(
     collectionPath: string,
     fileName: string,
   ): Promise<SuccessInterface | ErrorInterface> {
-    const folderManager = new FolderManager();
     const filePath = `${collectionPath}/${fileName}`;
-
-    const isLocked = await folderManager.IsDirectoryLocked(collectionPath);
-
-    if (!("data" in isLocked)) {
-      return this.responseHelper.Error("Failed to check directory lock status");
-    }
-
-    if (isLocked.data === false) {
-      // Directory not locked - delete directly
-      const deleteResponse = await this.DeleteFile(filePath);
-      return "data" in deleteResponse
-        ? this.responseHelper.Success("File deleted successfully")
-        : this.responseHelper.Error("Failed to delete file");
-    } else {
-      // Directory locked - unlock, delete, relock
-      const unlockResponse = await folderManager.UnlockDirectory(collectionPath);
-
-      if (!("data" in unlockResponse)) {
-        return this.responseHelper.Error("Failed to unlock directory");
-      }
-
-      const deleteResponse = await this.DeleteFile(filePath);
-
-      if (!("data" in deleteResponse)) {
-        // Attempt to relock even if delete failed
-        await folderManager.LockDirectory(collectionPath);
-        return this.responseHelper.Error("Failed to delete file");
-      }
-
-      const lockResponse = await folderManager.LockDirectory(collectionPath);
-
-      if (!("data" in lockResponse)) {
-        return this.responseHelper.Error("File deleted but failed to relock directory");
-      }
-
-      return this.responseHelper.Success("File deleted successfully");
-    }
+    const deleteResponse = await this.DeleteFile(filePath);
+    return "data" in deleteResponse
+      ? this.responseHelper.Success("File deleted successfully")
+      : this.responseHelper.Error("Failed to delete file");
   }
 }

--- a/source/engine/Filesystem/FolderManager.ts
+++ b/source/engine/Filesystem/FolderManager.ts
@@ -77,17 +77,6 @@ export default class FolderManager {
     }
   }
 
-  public async LockDirectory(
-    path: string,
-  ): Promise<SuccessInterface | ErrorInterface> {
-    try {
-      await this.fileSystem.chmod(path, 0o000);
-      return this.responseHelper.Success(`Directory locked: ${path}`);
-    } catch (error) {
-      return this.responseHelper.Error(`Failed to lock directory: ${error}`);
-    }
-  }
-
   public async UnlockDirectory(
     path: string,
   ): Promise<SuccessInterface | ErrorInterface> {
@@ -96,18 +85,6 @@ export default class FolderManager {
       return this.responseHelper.Success(`Directory unlocked: ${path}`);
     } catch (error) {
       return this.responseHelper.Error(`Failed to unlock directory: ${error}`);
-    }
-  }
-
-  public async IsDirectoryLocked(
-    path: string,
-  ): Promise<SuccessInterface | ErrorInterface> {
-    try {
-      const stats = await this.fileSystem.stat(path);
-      const isLocked = (stats.mode & 0o200) === 0; // no write permission for owner
-      return this.responseHelper.Success(isLocked);
-    } catch (error) {
-      return this.responseHelper.Error(`Failed to check lock status: ${error}`);
     }
   }
 

--- a/source/server/controller/Auth/RoleManagement.controller.ts
+++ b/source/server/controller/Auth/RoleManagement.controller.ts
@@ -47,6 +47,16 @@ export default class RoleManagementController {
     );
   }
 
+  public async deleteRole(request: FastifyRequest, reply: FastifyReply): Promise<ResponseBuilder> {
+    const { roleName } = request.params as { roleName: string };
+
+    const result = await this.authService.deleteRole(roleName);
+    if (!result.success) {
+      return sendResponse(reply, buildResponse(StatusCodes.BAD_REQUEST, result.message));
+    }
+    return sendResponse(reply, buildResponse(StatusCodes.OK, result.message));
+  }
+
   public async listPermissions(
     request: FastifyRequest,
     reply: FastifyReply,

--- a/source/server/controller/Operation/CRUD.controller.ts
+++ b/source/server/controller/Operation/CRUD.controller.ts
@@ -388,23 +388,15 @@ export default class CRUDController {
     const DB_Collection =
       await databaseInstance.createCollection(collectionName);
 
-    if (isMany) {
-      const deleteResult = await DB_Collection.delete(query).deleteMany();
-      console.log(deleteResult);
-      if (!deleteResult || deleteResult.statusCode !== StatusCodes.OK) {
-        return buildResponse(
-          StatusCodes.INTERNAL_SERVER_ERROR,
-          "Failed to delete document",
-        );
-      } else {
-        const deleteResult = await DB_Collection.delete(query).deleteOne();
-        if (!deleteResult || deleteResult.statusCode !== StatusCodes.OK) {
-          return buildResponse(
-            StatusCodes.INTERNAL_SERVER_ERROR,
-            "Failed to delete document",
-          );
-        }
-      }
+    const deleteResult = isMany
+      ? await DB_Collection.delete(query).deleteMany()
+      : await DB_Collection.delete(query).deleteOne();
+
+    if (!deleteResult || deleteResult.statusCode !== StatusCodes.OK) {
+      return buildResponse(
+        StatusCodes.INTERNAL_SERVER_ERROR,
+        "Failed to delete document",
+      );
     }
 
     return buildResponse(StatusCodes.OK, "Document deleted successfully");

--- a/source/server/router/Routers/RoleManagement.routes.ts
+++ b/source/server/router/Routers/RoleManagement.routes.ts
@@ -23,4 +23,10 @@ export default async function roleManagementRouter(fastify: FastifyInstance): Pr
     { preHandler: [requireAuth, requireFreshPassword, requirePermission(PERMISSIONS.ROLE_VIEW)] },
     async (request, reply) => new RoleManagementController().listPermissions(request, reply),
   );
+
+  fastify.delete(
+    "/:roleName",
+    { preHandler: [requireAuth, requireFreshPassword, requirePermission(PERMISSIONS.ROLE_DELETE)] },
+    async (request, reply) => new RoleManagementController().deleteRole(request, reply),
+  );
 }


### PR DESCRIPTION
### Summary
Introduces Model Context Protocol (MCP) server support for AI agent integration and resolves several critical bugs in aggregation and CRUD operations.

### Changes
- **MCP Integration**: New Streamable HTTP MCP server on port 27020 with 32 tools covering DB/Collection/Document/User/Role management.
- **Security**: Redacted `encryptionKey` from collection metadata responses.
- **Bug Fixes**:
  - Fixed `$sum` and `$avg` crashing on literal numeric operands in aggregation.
  - Fixed logic error in `deleteDocumentByQuery` where `isMany` logic was incorrectly nested.
  - Fixed `totalDocuments` count to exclude internal index directories.
  - Added missing `role:delete` permission and controller logic.
- **Cleanup**: Removed unused file/folder locking (chmod) logic that was redundant and causing unnecessary FS operations.
- **Documentation**: Comprehensive MCP guide added to web docs and README.

### Verification
- Tested MCP login and tool execution via Claude Desktop and MCP-CLI.
- Verified aggregation fixes with unit tests for literal operands.
- Confirmed `totalDocuments` returns correct file count without internal folders.