### PR TITLE
ci: add scheduled registry load test for axiodb

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Registry Install Load Test
+
+on:
+  schedule:
+    # Times are IST (UTC+5:30); GitHub Actions cron is UTC only.
+    - cron: "30 0 * * *"   # 6:00 AM IST
+    - cron: "30 5 * * *"   # 11:00 AM IST
+    - cron: "30 8 * * *"   # 2:00 PM IST
+    - cron: "30 11 * * *"  # 5:00 PM IST
+    - cron: "30 17 * * *"  # 11:00 PM IST
+  workflow_dispatch: {}
+
+jobs:
+  install-load-test:
+    name: "Install axiodb@latest x1000"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Install axiodb@latest 1000 times from private registry
+        run: |
+          mkdir -p runs && cd runs
+          for i in $(seq 1 1000); do
+            echo "=== Run $i/1000 ==="
+            folder="task_$i"
+            mkdir "$folder"
+            (
+              cd "$folder"
+              npm init -y > /dev/null
+              npm install axiodb@latest
+            )
+          done


### PR DESCRIPTION
## Summary
This PR introduces a scheduled GitHub Actions workflow designed to perform a 'load test' on the registry by installing the `axiodb` package 1,000 times.

## Changes
- Added `.github/workflows/test.yml`.
- Configured a cron schedule to run 5 times daily (IST timings).
- Implemented a bash loop that initializes a dummy project and installs `axiodb@latest` sequentially 1,000 times.

## Verification
- [ ] **Warning:** The current implementation is sequential and may take ~3 hours to complete.
- [ ] **Resource Abuse:** Need to verify if this violates GitHub's Terms of Service regarding runner usage.
- [ ] **Success Rate:** No error handling currently exists; monitoring is manual via GitHub logs.