### PR TITLE
chore: update version to 12.10.23 and add homepage to package.json; r…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Registry Install Load Test
 
 on:
+  push:
+    branches: [main]
+    paths: [".github/workflows/test.yml"]
   schedule:
     # Times are IST (UTC+5:30); GitHub Actions cron is UTC only.
     - cron: "30 0 * * *"   # 6:00 AM IST

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "12.10.22",
+  "version": "12.10.23",
   "description": "The Pure JavaScript Alternative to SQLite. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",
@@ -49,6 +49,7 @@
   ],
   "author": "Ankan Saha",
   "license": "MIT",
+  "homepage": "https://axiodb.in",
   "funding": {
     "type": "git",
     "url": "https://github.com/sponsors/AnkanSaha"


### PR DESCRIPTION
This pull request includes a few small but important updates to the project configuration and CI workflow. The `test.yml` workflow is now triggered on pushes to the `main` branch, and the `package.json` file has been updated with a new version and homepage URL.

- **CI/CD Workflow Updates:**
  * The `.github/workflows/test.yml` workflow is now configured to run on pushes to the `main` branch, in addition to its scheduled runs.

- **Project Metadata Updates:**
  * The `package.json` version has been bumped from `12.10.22` to `12.10.23`.
  * A `homepage` field has been added to `package.json` with the value `https://axiodb.in`.…efine GitHub Actions trigger for test workflow