### PR TITLE
fix: update load test count from 1000 to 200 in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   install-load-test:
-    name: "Install axiodb@latest x1000"
+    name: "Install axiodb@latest x200"
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node.js
@@ -23,11 +23,11 @@ jobs:
         with:
           node-version: "20.x"
 
-      - name: Install axiodb@latest 1000 times from private registry
+      - name: Install axiodb@latest 200 times from private registry
         run: |
           mkdir -p runs && cd runs
-          for i in $(seq 1 1000); do
-            echo "=== Run $i/1000 ==="
+          for i in $(seq 1 200); do
+            echo "=== Run $i/200 ==="
             folder="task_$i"
             mkdir "$folder"
             (


### PR DESCRIPTION
### Summary
Reduced the number of load test iterations from 1000 to 200 in the CI workflow to prevent excessive run times and potential registry rate-limiting.

### Changes
- Updated GitHub Actions job name to reflect 200 iterations.
- Modified the shell loop in `.github/workflows/test.yml` from `seq 1 1000` to `seq 1 200`.
- Updated logging messages to match the new iteration count.

### Verification
- Workflow runs sequentially for 200 iterations without hitting GitHub Actions timeout limits.