### PR TITLE
fix: bump version to 12.10.24 and fix typo in warning message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "12.10.23",
+  "version": "12.10.24",
   "description": "The Pure JavaScript Alternative to SQLite. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/source/client/PooledConnection.ts
+++ b/source/client/PooledConnection.ts
@@ -262,7 +262,7 @@ export default class PooledConnection {
         pending.reject(new Error(response.error || response.message));
       }
     } else {
-      console.warn(`[AxioDBCloud] Received response for unknown request: ${response.id}`);
+      console.warn(`[AxioDBCloud] Received response for unknown request occured: ${response.id}`);
     }
   }
 


### PR DESCRIPTION
This pull request contains a version bump for the `axiodb` package and a minor logging message update in the `PooledConnection` class.

Versioning:

* Updated the package version in `package.json` from `12.10.23` to `12.10.24` to reflect the latest changes.

Logging improvements:

* Improved the warning message in `PooledConnection.ts` to clarify when a response is received for an unknown request.…age in PooledConnection