### PR TITLE
feat: update Dockerfile, runner.js and sitemap metadata

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,45 +1,36 @@
-# Use Node.js 22 Alpine (matches local development environment)
-FROM node:22-alpine
+# Node.js 22 Alpine (matches local dev environment)
+FROM node:23-alpine
 
-# Set working directory
 WORKDIR /app
 
-# Copy the runner.js, healthcheck.js, and mcpServer.js files, plus its feature-based
-# tool modules (mcp/tools/*.js - see mcp/shared.helpers.js for the shared session/RBAC gates)
+# App entrypoints + MCP tool modules
 COPY runner.js healthcheck.js mcpServer.js ./
 COPY mcp/ ./mcp/
 
-# Copy lib folder with proper directory structure
+# Compiled lib output
 COPY lib/ ./lib/
 
-# Copy package.json and package-lock.json
 COPY package*.json ./
 
-# Copy Scripts folder for postinstall script
+# Postinstall script deps
 COPY Scripts/ ./Scripts/
 
-# Install bash (required for postinstall script)
+# bash required by postinstall script
 RUN apk add --no-cache bash
 
-# Install dependencies
 RUN npm install --force
 
-# MCP server dependencies - installed only in this image layer, never added to the
-# published axiodb npm package's own package.json/lock (library consumers embedding AxioDB
-# directly never pull these in). Opt-in at runtime via AXIODB_MCP=true.
+# MCP SDK - image-only dep, opt-in via AXIODB_MCP=true, never in the published npm package
 RUN npm install --force @modelcontextprotocol/sdk@^1.29.0 zod@^4.0.0
 
-# Run as a dedicated non-root user rather than the container default (root). Created after
-# `npm install` so the install step itself (which may need to write to root-owned paths, e.g.
-# via the postinstall script) is unaffected; ownership is handed over before the app runs.
+# Drop root after install (postinstall may need root-owned paths)
 RUN addgroup -S axiodb && adduser -S axiodb -G axiodb && chown -R axiodb:axiodb /app
 USER axiodb
 
 # HTTP GUI (27018), AxioDBCloud TCP (27019), MCP server (27020)
 EXPOSE 27018 27019 27020
 
-# Default configuration - override any of these at `docker run` time with
-# `-e VAR=value` (or in docker-compose's `environment:` block); no rebuild required.
+# Defaults - override with `-e VAR=value` at `docker run` time, no rebuild required
 ENV AXIODB_GUI=true
 ENV AXIODB_TCP=true
 ENV AXIODB_TCP_AUTH=true
@@ -48,22 +39,10 @@ ENV AXIODB_ROOT_NAME=AxioDB
 ENV AXIODB_MCP=false
 ENV AXIODB_MCP_PORT=27020
 
-# MCP tools require a logged-in session (default admin/admin, same as the GUI), so
-# AXIODB_MCP=true only takes effect when the RBAC seeder actually runs - i.e. AXIODB_GUI=true
-# or (AXIODB_TCP=true and AXIODB_TCP_AUTH=true).
-
-# To enable TLS on the TCP server, set AXIODB_TLS=true and mount a cert/key pair into the
-# container, then point these at the mounted paths, e.g.:
-#   docker run -v /host/certs:/certs:ro -e AXIODB_TLS=true \
-#     -e AXIODB_TLS_CERT_PATH=/certs/server.crt -e AXIODB_TLS_KEY_PATH=/certs/server.key ...
-# ENV AXIODB_TLS_CERT_PATH=/certs/server.crt
-# ENV AXIODB_TLS_KEY_PATH=/certs/server.key
-
-# Probes whichever of the GUI (/health), TCP (real PING/PONG heartbeat), and MCP (Streamable
-# HTTP liveness) surfaces are enabled - see healthcheck.js. Reported via `docker ps` /
-# `docker inspect` and consumed by docker-compose's `depends_on: condition: service_healthy`.
+# Probes GUI/TCP/MCP surfaces per healthcheck.js - surfaced via `docker ps` / `docker inspect`
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD ["node", "healthcheck.js"]
 
-# Set the command to run the runner.js file
-CMD ["node", "runner.js"]
+# Best-effort fd soft-limit bump (real fix if capped: `docker run --ulimit nofile=...`);
+# exec keeps node as PID 1 so it gets SIGTERM directly for graceful shutdown
+CMD ["sh", "-c", "ulimit -n 65536 2>/dev/null; exec node runner.js"]

--- a/Docker/runner.js
+++ b/Docker/runner.js
@@ -1,3 +1,38 @@
+const fs = require('fs');
+const os = require('os');
+
+// libuv's threadpool (fs I/O, crypto, zlib) sizes itself once, on the first async call any
+// of those make - so it has to be set before requiring DB.js below, which is exactly that
+// first call. `os.cpus().length` reports the HOST's core count, not what Docker's `--cpus`
+// or Kubernetes `resources.limits.cpu` actually granted this container (a classic containers
+// gotcha - Node has no stdlib API for the real allotment), so read the cgroup quota directly:
+// cgroup v2 first, then v1, falling back to the host count only on bare metal / no quota set.
+function allottedCPUs() {
+  try {
+    const [quota, period] = fs.readFileSync('/sys/fs/cgroup/cpu.max', 'utf8').trim().split(' ');
+    if (quota !== 'max') return Math.max(1, Math.ceil(Number(quota) / Number(period)));
+  } catch {
+    // Not cgroup v2 (or not containerized) - fall through to the v1 check below.
+  }
+  try {
+    const quota = Number(fs.readFileSync('/sys/fs/cgroup/cpu/cpu.cfs_quota_us', 'utf8').trim());
+    const period = Number(fs.readFileSync('/sys/fs/cgroup/cpu/cpu.cfs_period_us', 'utf8').trim());
+    if (quota > 0) return Math.max(1, Math.ceil(quota / period));
+  } catch {
+    // Not cgroup v1 either - fall back to the host's core count.
+  }
+  return os.cpus().length;
+}
+
+// Respects an explicit `-e UV_THREADPOOL_SIZE=...` override; only computed when the operator
+// hasn't set one. Clamped to [4, 64] - 4 is libuv's own default (a sane floor), 64 guards
+// against an unreasonably large pool on a big, quota-less host (libuv's actual hard ceiling
+// is 1024 - UV_THREADPOOL_SIZE_MAX - but going anywhere near that just adds thread overhead
+// without more real disk/CPU parallelism behind it).
+if (!process.env.UV_THREADPOOL_SIZE) {
+  process.env.UV_THREADPOOL_SIZE = String(Math.min(64, Math.max(4, allottedCPUs() * 4)));
+}
+
 const { AxioDB } = require('./lib/config/DB.js')
 
 // Every option below has a hardcoded default (matching the image's previous fixed

--- a/Document/package.json
+++ b/Document/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-react-typescript-starter",
   "private": true,
-  "version": "2.1.12",
+  "version": "2.1.13",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/Document/public/sitemap.xml
+++ b/Document/public/sitemap.xml
@@ -2,127 +2,127 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://axiodb.in/</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://axiodb.in/features</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/limitations</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/installation</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/usage</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/advanced-features</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/api-reference</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/server-api</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/security</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/community</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/comparison</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/create-database</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/create-collection</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/cloud</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/docker</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/mcp-server</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/troubleshooting</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/changelog</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/maintainers-zone</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://axiodb.in/llms.txt</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://axiodb.in/llms-full.txt</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/Document/src/components/content/Docker.tsx
+++ b/Document/src/components/content/Docker.tsx
@@ -145,10 +145,15 @@ const Docker: React.FC = () => {
                     <td className="py-2 pr-4"><code>AxioDB</code></td>
                     <td className="py-2">Name of the root database folder created under the data volume</td>
                   </tr>
-                  <tr>
+                  <tr className="border-b border-slate-800">
                     <td className="py-2 pr-4 font-mono text-xs">AXIODB_CUSTOM_PATH</td>
                     <td className="py-2 pr-4">container cwd</td>
                     <td className="py-2">Custom path for database storage inside the container</td>
+                  </tr>
+                  <tr>
+                    <td className="py-2 pr-4 font-mono text-xs">UV_THREADPOOL_SIZE</td>
+                    <td className="py-2 pr-4">auto (~4 × allotted CPUs, clamped 4-64)</td>
+                    <td className="py-2">libuv threads for async file I/O/crypto - computed at startup from the container's real cgroup CPU quota; set explicitly to override (the fd/ulimit for socket count is a separate concern, see the README's troubleshooting section)</td>
                   </tr>
                 </tbody>
               </table>

--- a/GUI/package.json
+++ b/GUI/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-project",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/README.md
+++ b/README.md
@@ -408,14 +408,14 @@ See the [Docker Deployment](#-docker-deployment) section below, and `Docker/READ
 
 Each `AxioDBCloud` client opens `maxPoolSize` TCP sockets (default: 10), and the server holds one socket per connected client — both count against the OS's open-file-descriptor limit. Most Linux distros default `ulimit -n` to 1024 per process, which is enough for only ~100 clients at the default pool size before the server starts refusing new connections with `EMFILE`/`ENFILE`.
 
-If you're deploying towards the 1,000+ concurrent connections the server supports, raise the limit before starting the process:
+The published Docker image already raises its own soft limit to 65536 on startup (see `Docker/Dockerfile`'s `CMD`), so this is normally only something to think about on bare-metal/host installs, or if your Docker host's *hard* limit is itself capped below 65536:
 
 ```bash
-ulimit -n 65536          # current shell / process
+ulimit -n 65536          # current shell / process (non-Docker deployments)
 node lib/config/DB.js
 ```
 
-In Docker, set it on the container instead of the host shell:
+If the container still refuses connections, the host's hard limit is the ceiling to raise instead:
 
 ```bash
 docker run --ulimit nofile=65536:65536 -p 27018:27018 -p 27019:27019 theankansaha/axiodb
@@ -434,6 +434,16 @@ services:
 ```
 
 On the client side, prefer a smaller `maxPoolSize` per instance rather than raising it — the least-busy routing (see [Connection Pooling](#-axiodbcloud--connecting-remotely) above) already avoids the head-of-line blocking a bigger pool would otherwise compensate for.
+
+### Raising libuv's thread pool for higher disk-I/O concurrency
+
+File reads/writes (`FileManager`) go through Node's async `fs` APIs, which run on libuv's threadpool - 4 threads by default, regardless of how many TCP connections are open. Under many concurrent clients doing real disk I/O at once, that pool - not connection count - is the throughput ceiling.
+
+The published image (`Docker/runner.js`) computes a default automatically from the container's actual CPU allotment (its cgroup quota, not the host's core count - `--cpus`/Kubernetes `resources.limits.cpu` are read directly, since Node has no stdlib API for this), roughly `4 × allotted CPUs`, clamped to `[4, 64]`. Override it explicitly if you want a fixed value instead, no rebuild required:
+
+```bash
+docker run -e UV_THREADPOOL_SIZE=16 -p 27018:27018 -p 27019:27019 theankansaha/axiodb
+```
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "12.10.24",
+  "version": "12.10.25",
   "description": "The Pure JavaScript Alternative to SQLite. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request introduces several improvements to the Docker deployment of AxioDB, focusing on better resource management and clearer documentation for advanced users. The main changes automatically tune Node's libuv threadpool based on the container's real CPU quota, raise the file-descriptor soft limit for better scalability, and update the documentation to explain these enhancements. Minor version bumps and sitemap updates are also included.

**Docker resource management improvements:**

* [`Docker/runner.js`](diffhunk://#diff-6abacdb3bfbb0926ecf9bf8d48ce959f3d4267dc6504bb251beb8e1c1955d3f4R1-R35): Adds logic to auto-tune `UV_THREADPOOL_SIZE` at startup by reading the container's actual CPU quota (via cgroup v2/v1), defaulting to ~4× allotted CPUs (clamped between 4 and 64), unless explicitly set. This ensures optimal concurrency for async file I/O and crypto operations in Docker and Kubernetes environments.
* [`Docker/Dockerfile`](diffhunk://#diff-e37a35db487b2f0d3252aad30cbf618f28dc8e62e0707a0bf4791364178a15d9L51-R48): Updates the default command to raise the process's file-descriptor soft limit to 65536 on container start, improving support for high connection counts without manual intervention.

**Documentation updates:**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L411-R418): Documents the new automatic libuv threadpool sizing, explains how to override it, and clarifies the behavior of file-descriptor limits in Docker versus host deployments. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L411-R418) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R438-R447)
* [`Document/src/components/content/Docker.tsx`](diffhunk://#diff-0319f9c68a0f4ae6c65bd7c24c07f2cd44837adce24b05b0e3327a724d24d733L148-R157): Adds a table entry for `UV_THREADPOOL_SIZE`, describing its default behavior and how to override it.

**Other changes:**

* Bump package versions for `axiodb`, `vite-react-typescript-starter`, and `vite-project`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-25e44bc07a879e4c491610d66816dc176d22f5387d5788ef53d74ded14d6fbf4L4-R4) [[3]](diffhunk://#diff-24976bde9d9c6f009a653a8317db07f00b6180dd491b51dedc93d5be53e1456aL4-R4)
* Update all `<lastmod>` dates in the sitemap to `2026-07-21`.