### PR TITLE
fix: update version to 12.10.26 in package.json; enhance delete opera…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "12.10.25",
+  "version": "12.10.26",
   "description": "The Pure JavaScript Alternative to SQLite. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/source/Services/CRUD Operation/Delete.operation.ts
+++ b/source/Services/CRUD Operation/Delete.operation.ts
@@ -147,13 +147,18 @@ export default class DeleteOperation {
       }
 
       // Fire-and-forget: Remove from indexes and invalidate cache asynchronously for faster response
-      new DeleteIndex(this.path).RemoveFromIndex(documentId, selectedFirstData?.data).catch(() => {});
-      InMemoryCache.invalidateByDocument(this.path, documentId).catch(() => {});
+      const isDeleted = await new DeleteIndex(this.path).RemoveFromIndex(documentId, selectedFirstData?.data).catch(() => {});
+      
+      if (isDeleted){ await InMemoryCache.invalidateByDocument(this.path, documentId).catch(() => {});
 
       return this.ResponseHelper.Success({
         message: "Data deleted successfully",
         deleteData: selectedFirstData?.data,
       });
+    } 
+    else {
+      return this.ResponseHelper.Error("Failed to remove from index & invalidate cache");
+    }
 
     } finally {
       // STEP 4: Always release lock (ACID: ensures no deadlock)
@@ -234,19 +239,24 @@ export default class DeleteOperation {
         }
 
         // Fire-and-forget: Remove from indexes asynchronously
-        deleteIndexService.RemoveFromIndex(
+        await deleteIndexService.RemoveFromIndex(
           SearchedData[i].fileName.split('.')[0],
           SearchedData[i].data
         ).catch(() => {});
       }
 
       // Fire-and-forget: Invalidate cache asynchronously
-      InMemoryCache.invalidateByDocuments(this.path, documentIds).catch(() => {});
+      const isRemoved = await InMemoryCache.invalidateByDocuments(this.path, documentIds).catch(() => {});
 
-      return this.ResponseHelper.Success({
-        message: "Data deleted successfully",
-        deleteData: SearchedData.map((data) => data.data),
-      });
+      if (isRemoved){
+        return this.ResponseHelper.Success({
+          message: "Data deleted successfully",
+          deleteData: SearchedData.map((data) => data.data),
+        });
+      }
+      else {
+        return this.ResponseHelper.Error("Failed to invalidate cache after deletion");
+      }
 
     } finally {
       // STEP 4: Always release ALL acquired locks (ACID: ensures no deadlock)


### PR DESCRIPTION
This pull request improves the reliability of the delete operation by ensuring that index removal and cache invalidation are completed successfully before confirming a successful deletion. If either step fails, an error response is returned instead of incorrectly reporting success. The changes also update the package version.

**Delete operation reliability improvements:**

* Changed single-document delete logic in `DeleteOperation` to await both index removal and cache invalidation, returning an error if either step fails.
* Changed multi-document delete logic in `DeleteOperation` to await index removal and cache invalidation for all documents, returning an error if cache invalidation fails.

**Version update:**

* Bumped the `package.json` version from `12.10.25` to `12.10.26`.