### PR TITLE
feat: add crash recovery tests and integrate into CI; update document…

### DIFF
--- a/.agents/skills/axiodb-development/SKILL.md
+++ b/.agents/skills/axiodb-development/SKILL.md
@@ -261,6 +261,11 @@ npm test                   # All tests
 npm test crud              # CRUD tests only
 npm test transaction       # Transaction tests only
 npm test read              # Read optimization tests
+npm test auth              # GUI RBAC tests only
+npm test tcp-auth          # TCP (AxioDBCloud) RBAC tests only
+npm test tcp-noauth        # TCP zero-auth backward-compat tests only
+npm test tcp-tls           # TCP TLS tests only
+npm test crash-recovery    # Real-SIGKILL crash-recovery tests only
 npm run lint               # ESLint
 
 # Development

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -7,6 +7,11 @@ npm test                   # All tests (separate processes due to singleton)
 npm test crud              # Only CRUD tests
 npm test transaction       # Only transaction tests
 npm test read              # Only read optimization tests
+npm test auth              # Only GUI RBAC tests
+npm test tcp-auth          # Only TCP (AxioDBCloud) RBAC tests
+npm test tcp-noauth        # Only TCP zero-auth backward-compat tests
+npm test tcp-tls           # Only TCP TLS tests
+npm test crash-recovery    # Only real-SIGKILL crash-recovery tests
 npm run lint               # ESLint
 npx tsc --noEmit          # Type check without emit
 ```

--- a/.github/copilot/instructions.md
+++ b/.github/copilot/instructions.md
@@ -236,6 +236,11 @@ npm test                   # All tests
 npm test crud              # CRUD tests only
 npm test transaction       # Transaction tests only
 npm test read              # Read optimization tests
+npm test auth              # GUI RBAC tests only
+npm test tcp-auth          # TCP (AxioDBCloud) RBAC tests only
+npm test tcp-noauth        # TCP zero-auth backward-compat tests only
+npm test tcp-tls           # TCP TLS tests only
+npm test crash-recovery    # Real-SIGKILL crash-recovery tests only
 npm run lint               # ESLint
 
 # Development

--- a/.github/workflows/Push.yml
+++ b/.github/workflows/Push.yml
@@ -200,6 +200,9 @@ jobs:
       - name: Run Read Optimization tests
         run: npm test read
 
+      - name: Run Crash Recovery tests
+        run: npm test crash-recovery
+
   publish_to_npm:
     needs: [detect_changes, test]
     if: needs.detect_changes.outputs.run_npm_github == 'true'

--- a/.github/workflows/auto_ci.yml
+++ b/.github/workflows/auto_ci.yml
@@ -182,6 +182,9 @@ jobs:
       - name: Run Read Optimization tests
         run: npm test read
 
+      - name: Run Crash Recovery tests
+        run: npm test crash-recovery
+
   auto-merge:
     name: "auto-merge"
     needs: [detect_changes, test]  # Wait for change detection and all test matrix jobs to complete

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,6 +315,11 @@ npm test                   # All tests (separate processes)
 npm test crud              # CRUD tests only
 npm test transaction       # Transaction tests only
 npm test read              # Read optimization tests
+npm test auth              # GUI RBAC tests only
+npm test tcp-auth          # TCP (AxioDBCloud) RBAC tests only
+npm test tcp-noauth        # TCP zero-auth backward-compat tests only
+npm test tcp-tls           # TCP TLS tests only
+npm test crash-recovery    # Real-SIGKILL crash-recovery tests only
 npm run lint               # ESLint
 
 # Development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ npm test        # Run all tests (separate processes)
 npm run lint    # ESLint check
 
 # Test specific module
-npm test crud | transaction | read
+npm test crud | transaction | read | auth | tcp-auth | tcp-noauth | tcp-tls | crash-recovery
 node Test/modules/crud.test.js
 ```
 

--- a/Document/src/data/changelog.ts
+++ b/Document/src/data/changelog.ts
@@ -12,6 +12,17 @@ export interface ChangelogEntry {
  */
 export const changelog: ChangelogEntry[] = [
   {
+    version: "13.1.3",
+    date: "2026-07-24",
+    title: "Fixed a process-exit hang; added real crash-recovery test coverage",
+    changes: [
+      "Fixed: InMemoryCache's background eviction interval had no unref(), so any short-lived script or CLI process using AxioDB (a stated core use case) would never exit on its own without an explicit process.exit() call - it now unrefs the same way IndexCache's cleanup interval already did",
+      "Added a real crash-recovery test suite (npm test crash-recovery): spawns a child process hammering inserts/updates, SIGKILLs it mid-write with no graceful shutdown, then verifies from a fresh process that every recovered document is complete and valid, and the WAL is cleaned up - this is the one guarantee this project had only reasoned about, never actually tested, until now",
+      "Added regression tests for this release's index-reordering fix, the cache-invalidation-scope fix, and the \"no match\" error contract for UpdateOne/UpdateMany/deleteOne/deleteMany",
+      "Wired the new crash-recovery suite into CI (Push.yml and auto_ci.yml Gate 4, alongside crud/transaction/read); synced the npm test command reference across CLAUDE.md, AGENTS.md, .claude/rules/commands.md, .github/copilot/instructions.md, and the axiodb-development skill, which had all drifted to list only crud/transaction/read",
+    ],
+  },
+  {
     version: "13.1.1",
     date: "2026-07-24",
     title: "Update and delete are now WAL-backed (full ACID coverage)",

--- a/Test/modules/crash-recovery.test.js
+++ b/Test/modules/crash-recovery.test.js
@@ -1,0 +1,223 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable no-undef */
+
+/**
+ * Crash Recovery Test Suite
+ *
+ * Everything else in this repo tests "does the logic look right" - this suite tests
+ * "does it survive an actual, uncontrolled process death mid-write". AxioDB is a
+ * singleton per process, so both the crashing side and the post-crash verification
+ * side run as separate spawned `node` processes (same reason Test/run.js isolates
+ * every suite into its own process).
+ */
+
+const TestRunner = require('../helpers/TestRunner');
+const { assert } = require('../helpers/assertions');
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const LIB_DB_PATH = path.resolve(__dirname, '../../lib/config/DB.js');
+
+/**
+ * Spawns `node -e <code>` and resolves with its stdout once it exits on its own
+ * (used for the "verify after recovery" side - it should run to completion normally).
+ */
+function runChildToCompletion(code, timeoutMs = 15000) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', ['-e', code], { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`Child process timed out after ${timeoutMs}ms. stderr: ${stderr}`));
+    }, timeoutMs);
+
+    child.stdout.on('data', (d) => { stdout += d.toString(); });
+    child.stderr.on('data', (d) => { stderr += d.toString(); });
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(new Error(`Child exited with code ${code}. stderr: ${stderr}`));
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
+}
+
+/**
+ * Spawns `node -e <code>`, lets it run for `aliveMs`, then SIGKILLs it - simulating
+ * a power loss / OOM kill with no graceful shutdown, no chance to flush anything
+ * that wasn't already fsynced.
+ */
+function runChildThenKill(code, aliveMs) {
+  return new Promise((resolve) => {
+    const child = spawn('node', ['-e', code], { stdio: 'ignore' });
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+    }, aliveMs);
+    child.on('exit', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+class CrashRecoveryTests extends TestRunner {
+  constructor() {
+    super('Crash Recovery Test Suite');
+    this.testDir = path.resolve(__dirname, '../TestCrashRecovery');
+  }
+
+  async setUp() {
+    if (fs.existsSync(this.testDir)) {
+      fs.rmSync(this.testDir, { recursive: true, force: true });
+    }
+    fs.mkdirSync(this.testDir, { recursive: true });
+  }
+
+  async tearDown() {
+    if (fs.existsSync(this.testDir)) {
+      fs.rmSync(this.testDir, { recursive: true, force: true });
+    }
+  }
+
+  async runTests() {
+    await this.describe('Crash Recovery (real SIGKILL mid-write)', async () => {
+      await this.test('SIGKILL during rapid inserts leaves no corrupted documents, recovers cleanly', async () => {
+        const dbPath = path.join(this.testDir, 'KillInsert');
+
+        const crashCode = `
+          const { AxioDB } = require(${JSON.stringify(LIB_DB_PATH)});
+          (async () => {
+            const db = new AxioDB({ GUI: false, RootName: 'CrashDB', CustomPath: ${JSON.stringify(dbPath)} });
+            const database = await db.createDB('TestDB');
+            const collection = await database.createCollection('Users');
+            let i = 0;
+            while (true) {
+              await collection.insert({ index: i, payload: 'x'.repeat(200) });
+              i++;
+            }
+          })();
+        `;
+
+        // Let it hammer inserts for a short window, then hard-kill - no clean shutdown.
+        await runChildThenKill(crashCode, 500);
+
+        // Fresh process, same directory - this is what a real restart does:
+        // Collection's constructor fires Transaction.recoverTransactions() on startup.
+        const collectionPath = path.join(dbPath, 'CrashDB', 'TestDB', 'Users');
+
+        const verifyCode = `
+          const { AxioDB } = require(${JSON.stringify(LIB_DB_PATH)});
+          (async () => {
+            const db = new AxioDB({ GUI: false, RootName: 'CrashDB', CustomPath: ${JSON.stringify(dbPath)} });
+            const database = await db.createDB('TestDB');
+            const collection = await database.createCollection('Users');
+            // Give the fire-and-forget recovery a moment to finish.
+            await new Promise((r) => setTimeout(r, 1000));
+            const result = await collection.query({}).Limit(100000).exec();
+            console.log(JSON.stringify({ count: result.data.documents.length }));
+            process.exit(0);
+          })();
+        `;
+        const stdout = await runChildToCompletion(verifyCode);
+        const { count } = JSON.parse(stdout.trim().split('\n').pop());
+
+        assert.ok(count > 0, 'Should have recovered at least some documents');
+
+        // Every persisted document file must be complete, valid JSON - never
+        // truncated or half-written, no matter where exactly the kill landed.
+        const files = fs.readdirSync(collectionPath).filter((f) => f.endsWith('.axiodb'));
+        assert.equal(files.length, count, 'File count on disk should match what the query returned');
+
+        for (const file of files) {
+          const content = fs.readFileSync(path.join(collectionPath, file), 'utf-8');
+          let parsed;
+          try {
+            parsed = JSON.parse(content);
+          } catch (e) {
+            throw new Error(`File ${file} is corrupted (not valid JSON): ${e.message}`);
+          }
+          assert.exists(parsed.documentId, `File ${file} should have an intact documentId field`);
+          assert.exists(parsed.payload, `File ${file} should have an intact payload field`);
+          assert.equal(parsed.payload.length, 200, `File ${file}'s payload should not be truncated`);
+        }
+
+        // The WAL for whichever transaction was in-flight at kill time must have
+        // been either replayed or undone, then cleaned up - it should never survive
+        // a completed recovery pass.
+        const txnDir = path.join(collectionPath, '.transactions');
+        if (fs.existsSync(txnDir)) {
+          const walFiles = fs.readdirSync(txnDir).filter((f) => f.endsWith('.wal'));
+          assert.equal(walFiles.length, 0, 'No .wal files should survive a completed recovery pass');
+        }
+
+        // Informational only (not a hard failure): a temp file written just before
+        // the kill, but never renamed into place, is a known minor leak - recovery
+        // reconstructs the final document correctly from the WAL either way, but
+        // nothing currently sweeps orphaned `.tmp-*` files themselves.
+        const tempFiles = fs.existsSync(collectionPath)
+          ? fs.readdirSync(collectionPath).filter((f) => f.includes('.tmp-'))
+          : [];
+        this.log(`     Recovered ${count} documents; ${tempFiles.length} orphaned temp file(s) left behind (known minor leak, not corruption)`, 'gray');
+      }, { timeout: 20000 });
+
+      await this.test('SIGKILL during a rapid update loop leaves the document in a valid before-or-after state', async () => {
+        const dbPath = path.join(this.testDir, 'KillUpdate');
+
+        const setupCode = `
+          const { AxioDB } = require(${JSON.stringify(LIB_DB_PATH)});
+          (async () => {
+            const db = new AxioDB({ GUI: false, RootName: 'CrashDB', CustomPath: ${JSON.stringify(dbPath)} });
+            const database = await db.createDB('TestDB');
+            const collection = await database.createCollection('Users');
+            await collection.insert({ name: 'Target', counter: 0 });
+            console.log('done');
+            process.exit(0);
+          })();
+        `;
+        await runChildToCompletion(setupCode);
+
+        const crashCode = `
+          const { AxioDB } = require(${JSON.stringify(LIB_DB_PATH)});
+          (async () => {
+            const db = new AxioDB({ GUI: false, RootName: 'CrashDB', CustomPath: ${JSON.stringify(dbPath)} });
+            const database = await db.createDB('TestDB');
+            const collection = await database.createCollection('Users');
+            let i = 0;
+            while (true) {
+              i++;
+              await collection.update({ name: 'Target' }).UpdateOne({ counter: i });
+            }
+          })();
+        `;
+        await runChildThenKill(crashCode, 500);
+
+        const verifyCode = `
+          const { AxioDB } = require(${JSON.stringify(LIB_DB_PATH)});
+          (async () => {
+            const db = new AxioDB({ GUI: false, RootName: 'CrashDB', CustomPath: ${JSON.stringify(dbPath)} });
+            const database = await db.createDB('TestDB');
+            const collection = await database.createCollection('Users');
+            await new Promise((r) => setTimeout(r, 1000));
+            const result = await collection.query({ name: 'Target' }).exec();
+            console.log(JSON.stringify({ doc: result.data.documents[0] || null }));
+            process.exit(0);
+          })();
+        `;
+        const stdout = await runChildToCompletion(verifyCode);
+        const { doc } = JSON.parse(stdout.trim().split('\n').pop());
+
+        assert.exists(doc, 'Document should still exist after recovery (update never deletes)');
+        assert.equal(doc.name, 'Target', 'Document identity should be intact');
+        assert.ok(typeof doc.counter === 'number', 'counter field should be a valid number, not corrupted/missing');
+
+        this.log(`     Document recovered with counter=${doc.counter} (some update in the rapid loop, never a torn value)`, 'gray');
+      }, { timeout: 20000 });
+    });
+  }
+}
+
+module.exports = CrashRecoveryTests;

--- a/Test/modules/crud.test.js
+++ b/Test/modules/crud.test.js
@@ -232,6 +232,59 @@ class CRUDTests extends TestRunner {
         assert.isSuccess(untouched);
         assert.ok(!untouched.data.documents[0].marked, 'age=78 document should be excluded by $ne and stay untouched');
       });
+
+      await this.test('UpdateOne/UpdateMany on a query matching nothing return an error, not a false success', async () => {
+        const oneResult = await this.collection
+          .update({ name: 'NoSuchUserAtAll' })
+          .UpdateOne({ marked: true });
+        assert.isError(oneResult, 'UpdateOne with no matching document should return an error');
+
+        const manyResult = await this.collection
+          .update({ name: 'NoSuchUserAtAll' })
+          .UpdateMany({ marked: true });
+        assert.isError(manyResult, 'UpdateMany with no matching documents should return an error');
+      });
+
+      await this.test('Updating one document does not disturb an unrelated one sharing the same indexed value', async () => {
+        // Regression test: two documents sharing an indexed field's value used to have
+        // their shared index bucket silently reordered on every update to either one -
+        // even when the update never touched that field - because the index-sync step
+        // did an unconditional remove+re-append regardless of whether the value changed.
+        // That could make a later "first match" query resolve to the wrong document.
+        const insertResult = await this.collection.insertMany([
+          { name: 'DupName', age: 40, marker: 'first' },
+          { name: 'DupName', age: 41, marker: 'second' }
+        ]);
+        assert.isSuccess(insertResult);
+        const [firstId, secondId] = insertResult.data.id;
+
+        // Update only the FIRST document, touching a field ('marker') that is not
+        // itself indexed, but 'name' (shared, unchanged) and 'age' (indexed, unchanged
+        // for this doc) both still get processed by index staging.
+        const updateResult = await this.collection
+          .update({ documentId: firstId })
+          .UpdateOne({ marker: 'first-updated' });
+        assert.isSuccess(updateResult);
+        assert.equal(updateResult.data.documentId, firstId, 'UpdateOne should report the document it actually targeted');
+
+        // The untouched document must be provably untouched, found by its own ID -
+        // not by relying on array position from a shared-value query.
+        const secondCheck = await this.collection.query({ documentId: secondId }).exec();
+        assert.isSuccess(secondCheck);
+        assert.equal(secondCheck.data.documents[0].marker, 'second', 'Untouched document must keep its original marker');
+        assert.equal(secondCheck.data.documents[0].age, 41, 'Untouched document must keep its original age');
+
+        // The updated document, found by its own ID, must reflect the change.
+        const firstCheck = await this.collection.query({ documentId: firstId }).exec();
+        assert.isSuccess(firstCheck);
+        assert.equal(firstCheck.data.documents[0].marker, 'first-updated', 'Updated document must reflect the change');
+
+        // A plain query on the shared 'name' value must still return both documents,
+        // regardless of internal bucket order.
+        const both = await this.collection.query({ name: 'DupName' }).exec();
+        assert.isSuccess(both);
+        assert.equal(both.data.documents.length, 2, 'Both documents sharing the indexed value must still be findable');
+      });
     });
 
     // CONCURRENT UPDATE Tests - ACID Compliance
@@ -475,6 +528,41 @@ class CRUDTests extends TestRunner {
 
         this.log(`✅ File integrity verified: version=${doc.version}, updateNumber=${doc.updateNumber}`, 'success');
       });
+
+      await this.test('Concurrent UpdateOne and deleteOne on the same document - no corruption either way', async () => {
+        const insertResult = await this.collection.insert({ name: 'UpdateDeleteRace', counter: 0 });
+        assert.isSuccess(insertResult);
+        const targetId = insertResult.data.documentId;
+
+        // Race an update against a delete on the exact same document. Whichever
+        // wins the lock first should complete cleanly; whichever loses should
+        // either serialize behind it (finding the doc already gone, if delete won)
+        // or complete normally (if update won and delete found nothing to remove
+        // afterwards) - either outcome is acceptable, but neither should throw an
+        // unhandled error, hang, or leave a corrupted/partial file.
+        const [updateResult, deleteResult] = await Promise.all([
+          this.collection.update({ documentId: targetId }).UpdateOne({ counter: 1 }),
+          this.collection.delete({ documentId: targetId }).deleteOne()
+        ]);
+
+        this.log(`     Update: ${'data' in updateResult ? 'succeeded' : 'failed'}, Delete: ${'data' in deleteResult ? 'succeeded' : 'failed'}`, 'gray');
+
+        // At least one of the two must have observed a real, non-crashing outcome.
+        assert.ok('data' in updateResult || 'data' in deleteResult, 'At least one of update/delete should complete');
+
+        // Whatever the final state is, it must be internally consistent: either the
+        // document is gone, or it exists as valid, uncorrupted data.
+        const finalState = await this.collection.query({ documentId: targetId }).exec();
+        assert.isSuccess(finalState);
+        if (finalState.data.documents.length > 0) {
+          const doc = finalState.data.documents[0];
+          assert.equal(doc.documentId, targetId, 'Surviving document must have the correct documentId');
+          assert.exists(doc.name, 'Surviving document must have an intact name field');
+          assert.equal(doc.name, 'UpdateDeleteRace', 'Surviving document must not be corrupted');
+        } else {
+          this.log('     Document was deleted - acceptable outcome of the race', 'gray');
+        }
+      });
     });
 
     // DELETE Tests
@@ -531,6 +619,18 @@ class CRUDTests extends TestRunner {
           .exec();
         assert.isSuccess(remaining);
         assert.equal(remaining.data.documents.length, 2, 'The two excluded documents (status x, y) should remain');
+      });
+
+      await this.test('deleteOne/deleteMany on a query matching nothing return an error, not a false success', async () => {
+        const oneResult = await this.collection
+          .delete({ name: 'NoSuchUserAtAll' })
+          .deleteOne();
+        assert.isError(oneResult, 'deleteOne with no matching document should return an error');
+
+        const manyResult = await this.collection
+          .delete({ name: 'NoSuchUserAtAll' })
+          .deleteMany();
+        assert.isError(manyResult, 'deleteMany with no matching documents should return an error');
       });
     });
 

--- a/Test/modules/read.test.js
+++ b/Test/modules/read.test.js
@@ -142,6 +142,69 @@ class ReadOptimizationTests extends TestRunner {
         );
       });
 
+      await this.test('Deleting one document evicts only its own cached queries', async () => {
+        // Same guarantee as the update test above, but for deleteOne - regression
+        // coverage for Transaction.commit() invalidating the whole collection's
+        // cache on every write instead of just the deleted document's entries.
+        const insertResult = await this.collection.insert({ name: 'CacheDeleteTarget', age: 500 });
+        const targetId = insertResult.data.documentId;
+
+        const queryA = { name: 'CacheDeleteTarget' };
+        const queryB = { age: { $gt: 55, $lt: 60 } }; // disjoint - shares no documents with queryA
+
+        await this.collection.query(queryA).exec();
+        await this.collection.query(queryB).exec();
+
+        const bBeforeStart = Date.now();
+        await this.collection.query(queryB).exec();
+        const bBeforeDuration = Date.now() - bBeforeStart;
+
+        await this.collection.delete({ documentId: targetId }).deleteOne();
+
+        const bAfterStart = Date.now();
+        await this.collection.query(queryB).exec();
+        const bAfterDuration = Date.now() - bAfterStart;
+
+        this.log(`     queryB cache hit before: ${bBeforeDuration}ms, after unrelated delete: ${bAfterDuration}ms`, 'gray');
+        assert.ok(bAfterDuration < 100, 'Unrelated cached query should remain a fast cache hit after an unrelated document is deleted');
+      });
+
+      await this.test('UpdateMany evicts only the cached queries for documents it actually touched', async () => {
+        const queryA = { age: { $gt: 30, $lt: 35 } };
+        const queryB = { age: { $gt: 55, $lt: 60 } }; // disjoint - UpdateMany below never touches these documents
+
+        await this.collection.query(queryA).exec();
+        await this.collection.query(queryB).exec();
+
+        const bBeforeStart = Date.now();
+        await this.collection.query(queryB).exec();
+        const bBeforeDuration = Date.now() - bBeforeStart;
+
+        await this.collection.update(queryA).UpdateMany({ batchMarked: true });
+
+        const bAfterStart = Date.now();
+        await this.collection.query(queryB).exec();
+        const bAfterDuration = Date.now() - bAfterStart;
+
+        this.log(`     queryB cache hit before: ${bBeforeDuration}ms, after disjoint UpdateMany: ${bAfterDuration}ms`, 'gray');
+        assert.ok(bAfterDuration < 100, 'Unrelated cached query should remain a fast cache hit after an UpdateMany that never matched it');
+      });
+
+      await this.test('A cached "no results" query is correctly invalidated after an insert that would now match', async () => {
+        // Inserts can't be selectively targeted (a brand-new documentId has no
+        // existing cache entry to evict) - they must broadly invalidate the whole
+        // collection, otherwise a cached empty/stale result set would stay wrong
+        // indefinitely instead of just until the next unrelated write.
+        const uniqueMarker = `insert-cache-check-${Date.now()}`;
+        const before = await this.collection.query({ name: uniqueMarker }).exec();
+        assert.equal(before.data.documents.length, 0, 'Should find nothing before the document exists');
+
+        await this.collection.insert({ name: uniqueMarker, age: 999 });
+
+        const after = await this.collection.query({ name: uniqueMarker }).exec();
+        assert.equal(after.data.documents.length, 1, 'Previously-cached empty result must be invalidated by the insert, not served stale');
+      });
+
       await this.test('DocumentId queries are cached', async () => {
         // Get a documentId first
         const firstResult = await this.collection.query({ name: 'Alice0' }).exec();

--- a/Test/modules/transaction.test.js
+++ b/Test/modules/transaction.test.js
@@ -106,6 +106,39 @@ class TransactionTests extends TestRunner {
 
         const afterCount = await this.collection.totalDocuments();
         assert.equal(afterCount.data.total, beforeCount.data.total);
+
+        // Stronger than a count check: the specific document must not be findable
+        // by any of its indexed fields either - a rollback that undid the file but
+        // left a stale index entry would still "work" by count but corrupt lookups.
+        const byName = await this.collection.query({ name: 'RollbackUser' }).exec();
+        assert.equal(byName.data.documents.length, 0, 'Rolled-back document must not be findable by name');
+        const byEmail = await this.collection.query({ email: 'rollback@test.com' }).exec();
+        assert.equal(byEmail.data.documents.length, 0, 'Rolled-back document must not be findable by its indexed email either');
+      });
+
+      await this.test('Rollback on a mixed insert+update+delete transaction undoes all three', async () => {
+        // The classic atomicity check: several different operation types in one
+        // transaction, rolled back instead of committed - every single one of them
+        // must revert, not just the last one or the first one.
+        await this.collection.insert({ name: 'RB_ToUpdate', email: 'rb-update@test.com', age: 60, status: 'original' });
+        await this.collection.insert({ name: 'RB_ToDelete', email: 'rb-delete@test.com', age: 61 });
+
+        const txn = this.collection.beginTransaction();
+        txn
+          .insert({ name: 'RB_NewInsert', email: 'rb-new@test.com', age: 62 })
+          .update({ name: 'RB_ToUpdate' }, { status: 'changed' })
+          .delete({ name: 'RB_ToDelete' });
+        await txn.rollback();
+
+        const newInsert = await this.collection.query({ name: 'RB_NewInsert' }).exec();
+        assert.equal(newInsert.data.documents.length, 0, 'Rolled-back insert must not exist');
+
+        const updated = await this.collection.query({ name: 'RB_ToUpdate' }).exec();
+        assert.equal(updated.data.documents.length, 1, 'Document targeted by rolled-back update must still exist');
+        assert.equal(updated.data.documents[0].status, 'original', 'Rolled-back update must restore the original field value, not the attempted new one');
+
+        const deleted = await this.collection.query({ name: 'RB_ToDelete' }).exec();
+        assert.equal(deleted.data.documents.length, 1, 'Document targeted by rolled-back delete must still exist');
       });
 
       await this.test('Empty transaction throws error', async () => {

--- a/Test/run.js
+++ b/Test/run.js
@@ -16,6 +16,7 @@
  *   node Test/run.js tcp-auth  # Run only TCP (AxioDBCloud) RBAC tests
  *   node Test/run.js tcp-noauth  # Run only TCP zero-auth backward-compat tests
  *   node Test/run.js tcp-tls   # Run only TCP TLS tests
+ *   node Test/run.js crash-recovery  # Run only real-SIGKILL crash-recovery tests
  */
 
 const { spawn } = require('child_process');
@@ -40,7 +41,8 @@ const testModules = {
   auth: './modules/auth.test.js',
   'tcp-auth': './modules/tcp-auth.test.js',
   'tcp-noauth': './modules/tcp-noauth.test.js',
-  'tcp-tls': './modules/tcp-tls.test.js'
+  'tcp-tls': './modules/tcp-tls.test.js',
+  'crash-recovery': './modules/crash-recovery.test.js'
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "13.1.2",
+  "version": "13.1.3",
   "description": "The Pure JavaScript Alternative to SQLite. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/source/Memory/memory.operation.ts
+++ b/source/Memory/memory.operation.ts
@@ -259,7 +259,7 @@ export class InMemoryCache {
 
   /** Periodically evicts expired cache entries and old search-query tracking. */
   private async autoResetCache(): Promise<void> {
-    setInterval(
+    const interval = setInterval(
       () => {
         if (this.cacheObject.size === 0) {
           return;
@@ -284,6 +284,13 @@ export class InMemoryCache {
       },
       parseInt(String(this.ttl)),
     );
+
+    // Background housekeeping must never be the reason a short-lived script or CLI
+    // tool (a stated core use case) can't exit on its own - same reasoning as
+    // IndexCache's cleanup interval.
+    if (interval.unref) {
+      interval.unref();
+    }
   }
 }
 export default new InMemoryCache(86400); // 24 hours


### PR DESCRIPTION
This pull request adds a comprehensive real crash-recovery test suite to AxioDB, fixes a process-exit hang in the in-memory cache, and introduces several important regression tests for recent bug fixes. It also synchronizes and expands the `npm test` command documentation across the codebase and CI, and wires the new crash-recovery tests into the continuous integration pipelines.

**Crash Recovery and Test Coverage Improvements:**

* Added a real crash-recovery test suite (`Test/modules/crash-recovery.test.js`) that simulates uncontrolled process death (SIGKILL) during inserts and updates, then verifies that all recovered documents are complete and valid, and that the write-ahead log (WAL) is properly cleaned up. This suite is now run in CI alongside other core tests. [[1]](diffhunk://#diff-bba129b8c5692531d6a753faba9e2a5ee1b4d6f27037afa53c99f2d0a6b5a0ecR1-R223) [[2]](diffhunk://#diff-1d0f9c4998a0fbb30b5da0e9c7e9792ddc6de918d973afd986d72c096067838aR14-R24) [[3]](diffhunk://#diff-180b61bac3d21c7729f3321b6baa42797689cd3c14dda9e37714170b684fc19dR203-R205) [[4]](diffhunk://#diff-4287a9b5dc3e126354df6b12654981a579e22bb6aa5869b6c2a5c6a30e4dc93dR185-R187)

* Fixed an issue where the `InMemoryCache`'s background eviction interval prevented short-lived scripts or CLI processes from exiting on their own, by ensuring the interval is `unref()`'d (as already done in `IndexCache`).

**Regression and Consistency Tests:**

* Added regression tests to ensure:
  - Index buckets are not silently reordered when updating a document that shares an indexed value with another document.
  - The cache invalidation scope fix is covered.
  - `UpdateOne`, `UpdateMany`, `deleteOne`, and `deleteMany` return an error when no documents match, rather than a false success.
  - Concurrent update and delete operations on the same document do not result in corruption or inconsistent state. [[1]](diffhunk://#diff-5d6365cb9907d20bece91e8e16531ee4de6889fcb5022eaaa1ac676fbba33afaR235-R287) [[2]](diffhunk://#diff-5d6365cb9907d20bece91e8e16531ee4de6889fcb5022eaaa1ac676fbba33afaR531-R565) [[3]](diffhunk://#diff-5d6365cb9907d20bece91e8e16531ee4de6889fcb5022eaaa1ac676fbba33afaR623-R634)

**Documentation and Command Reference Synchronization:**

* Updated and synchronized the `npm test` command references across all documentation files (`CLAUDE.md`, `AGENTS.md`, `.claude/rules/commands.md`, `.github/copilot/instructions.md`, `.agents/skills/axiodb-development/SKILL.md`) to include the new and existing test suites for CRUD, transactions, read optimization, RBAC, TCP, TLS, and crash recovery. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L21-R21) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R318-R322) [[3]](diffhunk://#diff-5d3c7946a6ecd544fef3273f7eb120e8d3d23743bf0317b283611717b815b809R10-R14) [[4]](diffhunk://#diff-6c64dfc2c7c95f25197a330f9effdc2c0fc0813de51152c4595a44e820af2c65R239-R243) [[5]](diffhunk://#diff-296344c2f8f87dc3d726e43fec0af0ce5b166775e2c0e9c9001bce5d700168b8R264-R268)

**Continuous Integration:**

* Integrated the new crash-recovery test suite into GitHub Actions workflows (`.github/workflows/Push.yml`, `.github/workflows/auto_ci.yml`) to ensure crash recovery is tested on every push and in automated CI gates. [[1]](diffhunk://#diff-180b61bac3d21c7729f3321b6baa42797689cd3c14dda9e37714170b684fc19dR203-R205) [[2]](diffhunk://#diff-4287a9b5dc3e126354df6b12654981a579e22bb6aa5869b6c2a5c6a30e4dc93dR185-R187)

**Changelog:**

* Documented all of the above changes in the `changelog.ts` for version 13.1.3.