### PR TITLE
feat: enhance transaction handling with WAL failure scenarios and cle…

### DIFF
--- a/Test/modules/transaction.test.js
+++ b/Test/modules/transaction.test.js
@@ -141,6 +141,118 @@ class TransactionTests extends TestRunner {
         assert.equal(deleted.data.documents.length, 1, 'Document targeted by rolled-back delete must still exist');
       });
 
+      await this.test('WAL append failure aborts the commit and rolls back', async () => {
+        // The WAL entry is the durable record of intent: if appendLog() fails
+        // (disk full, EIO) the commit must NOT proceed to mutate documents, and
+        // must leave no orphaned .tmp staging files behind.
+        await this.collection.insert({ name: 'WAL_Existing', email: 'wal-existing@test.com', age: 70, status: 'original' });
+
+        const txn = this.collection.beginTransaction();
+        txn
+          .insert({ name: 'WAL_NewInsert', email: 'wal-new@test.com', age: 71 })
+          .update({ name: 'WAL_Existing' }, { status: 'changed' });
+
+        // Inject a WAL write failure - appendLog returns an error result (it does
+        // not throw), exactly like a real disk failure would.
+        txn.WAL.appendLog = async () => ({ status: false, message: 'injected WAL failure' });
+
+        const result = await txn.commit();
+        assert.isError(result);
+
+        // Query WAL_NewInsert (the rolled-back insert) under the spy: this is the query
+        // that resolves the phantom index entry staged in the shared in-memory cache and
+        // points at the never-written file, so it must produce no "Failed to read file".
+        const originalError = console.error;
+        let phantomRead = false;
+        console.error = (...args) => {
+          if (args.some((a) => String(a).includes('Failed to read file'))) phantomRead = true;
+        };
+        let newInsert, existing;
+        try {
+          newInsert = await this.collection.query({ name: 'WAL_NewInsert' }).exec();
+          existing = await this.collection.query({ name: 'WAL_Existing' }).exec();
+        } finally {
+          console.error = originalError;
+        }
+        assert.equal(newInsert.data.documents.length, 0, 'Insert must not be applied when the WAL write failed');
+        assert.equal(existing.data.documents.length, 1, 'Update target must still exist');
+        assert.equal(existing.data.documents[0].status, 'original', 'Update must not be applied when the WAL write failed');
+        assert.equal(phantomRead, false, 'Rollback must clean the in-memory index so no phantom (never-written) file is read');
+
+        // No orphaned .tmp staging file may remain anywhere in the data dir.
+        const findTmp = (dir) => {
+          let found = false;
+          for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            const full = `${dir}/${entry.name}`;
+            if (entry.isDirectory()) {
+              found = findTmp(full) || found;
+            } else if (entry.name.includes('.tmp-')) {
+              found = true;
+            }
+          }
+          return found;
+        };
+        assert.equal(findTmp(this.testDir), false, 'A failed commit must not leak .tmp staging files');
+      });
+
+      await this.test('Staging (.tmp) write failure aborts the commit and cleans orphaned .tmp files', async () => {
+        // Fix #2 + #3: if a .tmp staging write fails partway through a multi-op
+        // transaction, the commit must abort AND rollback must remove the .tmp file
+        // that the earlier, already-staged op left behind.
+        const txn = this.collection.beginTransaction();
+        txn
+          .insert({ name: 'STAGE_First', email: 'stage-first@test.com', age: 80 })
+          .insert({ name: 'STAGE_Second', email: 'stage-second@test.com', age: 81 });
+
+        // Let the WAL append succeed (real), but fail the SECOND .tmp staging write,
+        // so the first op's .tmp is a genuine orphan that rollback must clean up.
+        let stageCalls = 0;
+        const originalWriteFile = txn.FileManager.WriteFile.bind(txn.FileManager);
+        txn.FileManager.WriteFile = async (filePath, data) => {
+          if (String(filePath).includes('.tmp-')) {
+            stageCalls++;
+            if (stageCalls >= 2) {
+              return { status: false, message: 'injected staging failure on 2nd op' };
+            }
+          }
+          return originalWriteFile(filePath, data);
+        };
+
+        const result = await txn.commit();
+        assert.isError(result);
+        assert.ok(stageCalls >= 2, 'The second staging write should have been attempted');
+
+        const originalError = console.error;
+        let phantomRead = false;
+        console.error = (...args) => {
+          if (args.some((a) => String(a).includes('Failed to read file'))) phantomRead = true;
+        };
+        let first, second;
+        try {
+          first = await this.collection.query({ name: 'STAGE_First' }).exec();
+          second = await this.collection.query({ name: 'STAGE_Second' }).exec();
+        } finally {
+          console.error = originalError;
+        }
+        assert.equal(first.data.documents.length, 0, 'First op must not be applied when a later staging write failed');
+        assert.equal(second.data.documents.length, 0, 'Second op must not be applied when its staging write failed');
+        assert.equal(phantomRead, false, 'Rollback must clean the in-memory index so no phantom (never-written) file is read');
+
+        // The first op DID write a .tmp file before the second failed - rollback must have removed it.
+        const findTmp = (dir) => {
+          for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            const full = `${dir}/${entry.name}`;
+            if (entry.isDirectory()) {
+              if (findTmp(full)) return true;
+            } else if (entry.name.includes('.tmp-')) {
+              return true;
+            }
+          }
+          return false;
+        };
+        assert.equal(findTmp(this.testDir), false, 'Rollback must clean the orphaned .tmp file from the already-staged op');
+      });
+
       await this.test('Empty transaction throws error', async () => {
         const txn = this.collection.beginTransaction();
         const result = await txn.commit();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "13.1.3",
+  "version": "13.1.4",
   "description": "The Pure JavaScript Alternative to SQLite. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/source/Services/Transaction/Transaction.service.ts
+++ b/source/Services/Transaction/Transaction.service.ts
@@ -255,6 +255,20 @@ export default class Transaction {
 
       await this.IndexManager.rollbackIndexUpdates();
 
+      // Remove any staged .tmp files an aborted executeOperations may have left
+      // behind (e.g. a mid-loop WAL/stage failure throws before applyChanges
+      // renames them into place), so aborted commits don't leak temp files.
+      for (const op of this.resolvedOperations) {
+        if (op.type === 'INSERT' || op.type === 'UPDATE') {
+          const fileName = op.fileName || `${op.documentId}${General.DBMS_File_EXT}`;
+          const tempFilePath = `${this.collectionPath}/${fileName}.tmp-${this.transactionId}`;
+          const tempExists = await this.FileManager.FileExists(tempFilePath);
+          if (tempExists.status) {
+            await this.FileManager.DeleteFile(tempFilePath);
+          }
+        }
+      }
+
       await this.LockManager.releaseAllLocks(this.lockedDocuments);
 
       await this.WAL.deleteWAL();
@@ -410,11 +424,26 @@ export default class Transaction {
         checksum: '',
       };
 
-      await this.WAL.appendLog(walEntry);
+      // The WAL entry is the durable record of intent - it MUST be persisted
+      // before we stage/apply the change. appendLog() returns an Error result
+      // instead of throwing, so an unchecked failure (disk full, EIO) would let
+      // the commit proceed and mutate a document with no log to recover from.
+      // Throwing here routes into commit()'s catch, which rolls the transaction back.
+      const appendResult = await this.WAL.appendLog(walEntry);
+      if (!appendResult.status) {
+        throw new Error(
+          `WAL append failed for document ${op.documentId} - aborting commit: ${(appendResult as ErrorInterface).message ?? ""}`,
+        );
+      }
 
       const tempFilePath = `${filePath}.tmp-${this.transactionId}`;
       if (op.type === 'INSERT' || op.type === 'UPDATE') {
-        await this.FileManager.WriteFile(tempFilePath, afterData!);
+        const tempWrite = await this.FileManager.WriteFile(tempFilePath, afterData!);
+        if (!tempWrite.status) {
+          throw new Error(
+            `Failed to stage document ${op.documentId} - aborting commit`,
+          );
+        }
       }
     }
   }

--- a/source/Services/Transaction/TransactionIndexManager.service.ts
+++ b/source/Services/Transaction/TransactionIndexManager.service.ts
@@ -195,9 +195,16 @@ export default class TransactionIndexManager {
   }
 
   public async rollbackIndexUpdates(): Promise<void> {
-    // Staged updates only ever lived in memory (this.stagedIndexUpdates) until
-    // commitIndexUpdates() wrote them - nothing was persisted, so rolling back is
-    // just discarding the staged map.
+    // stageIndexUpdates() reads the index via IndexCache.getIndex(), which returns
+    // the LIVE cached object (not a copy), and mutates its indexEntries/sortedValues
+    // in place - so the shared in-memory cache is already polluted by the time we
+    // roll back. Discarding the staged map alone would leave those mutations visible
+    // (e.g. a phantom entry pointing at a document the aborted transaction never
+    // wrote). Invalidate the touched fields so the next read reloads the clean copy
+    // from disk - disk is untouched on this path because commitIndexUpdates() never ran.
+    for (const fieldName of this.stagedIndexUpdates.keys()) {
+      await this.indexCache.invalidateIndex(fieldName);
+    }
     this.stagedIndexUpdates.clear();
   }
 


### PR DESCRIPTION
This pull request improves the safety and reliability of the transaction commit and rollback logic, especially around handling failures during disk operations. The changes ensure that if a write-ahead log (WAL) append or file staging operation fails, the transaction is fully aborted, all temporary files are cleaned up, and no in-memory index corruption or orphaned files remain. Comprehensive tests have been added to verify these behaviors.

**Transaction Failure Handling Improvements:**

- In `Transaction.service.ts`, the transaction commit logic now checks the result of `WAL.appendLog` and file staging writes, aborting and rolling back the transaction if either fails, preventing partial commits and orphaned files.
- The rollback logic now explicitly deletes any `.tmp` staging files left behind by aborted operations, ensuring the data directory is not polluted by failed transactions.
- The index rollback method now invalidates any in-memory indexes touched by a failed transaction, preventing "phantom" index entries that could reference non-existent documents.

**Testing Enhancements:**

- Two new tests in `transaction.test.js` verify that WAL append failures and staging write failures during a transaction both result in a full rollback, no in-memory index corruption, and no orphaned `.tmp` files.

**Version Bump:**

- The package version is incremented to `13.1.4` to reflect these fixes.