### PR TITLE
Maintainer/ankan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "14.2.5",
+  "version": "14.2.6",
   "description": "The Pure JavaScript Alternative to SQLite. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/source/Services/Index/IndexCache.service.ts
+++ b/source/Services/Index/IndexCache.service.ts
@@ -36,10 +36,9 @@ interface CachedIndex {
  * Features:
  * - Eagerly loads all indexes on collection initialization
  * - Keeps indexes in both memory (speed) and disk (persistence) as JSONL
- * - Cold start recovery: Loads from disk (streaming) on cache miss
+ * - Cold start recovery: Streams from disk on cache miss
  * - Thread-safe with simple lock mechanism
  * - Dual-write: Updates both memory and disk atomically
- * - Backward compatible: auto-migrates old .axiodb + index.meta.json formats
  *
  * @example
  * ```typescript
@@ -230,23 +229,7 @@ export class IndexCache {
         }
       }
 
-      // Fallback: stream old .axiodb file if it exists (migration not yet run)
-      const oldIndexPath = `${this.indexFolderPath}/${fieldName}${General.DBMS_File_EXT}`;
-      const oldContent = await this.fileManager.ReadFile(oldIndexPath);
-      if (oldContent.status) {
-        try {
-          const indexData = this.converter.ToObject(oldContent.data);
-          if (indexData && indexData.fieldName) {
-            this.cache.set(fieldName, {
-              data: indexData,
-              loadedAt: new Date(),
-              expiresAt: Date.now() + this.generateRandomTTL(),
-              path: oldIndexPath,
-            });
-            return indexData;
-          }
-        } catch { /* parse error */ }
-      }
+      // Streaming read failed — index file may not exist (normal for unindexed fields)
     } catch { /* index doesn't exist */ }
 
     return null;


### PR DESCRIPTION
This pull request includes a version bump for the `axiodb` package and refines the index cache migration logic and documentation. The most important changes are summarized below:

**Versioning:**

* Updated the package version in `package.json` from `14.2.5` to `14.2.6`.

**Index cache migration and documentation:**

* Removed legacy fallback logic for loading old `.axiodb` index files in `IndexCache`, simplifying cold start recovery and migration handling.
* Updated the `IndexCache` service documentation to clarify that cold start recovery streams from disk on cache miss, and removed the claim of backward compatibility with old `.axiodb` and `index.meta.json` formats.