### PR TITLE
chore(release): bump version to 14.2.7 and cleanup runner whitespace

### DIFF
--- a/Docker/runner.js
+++ b/Docker/runner.js
@@ -75,5 +75,4 @@ if (parseBoolean(process.env.AXIODB_MCP, false)) {
   require('./mcpServer.js')(axioDBInstance);
 }
 
-
 module.exports = axioDBInstance;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "14.2.6",
+  "version": "14.2.7",
   "description": "The Pure JavaScript Alternative to SQLite. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
### Summary
This PR updates the package version and performs minor cleanup in the Docker runner utility.

### Changes
- **package.json**: Bump version from `14.2.6` to `14.2.7`.
- **Docker/runner.js**: Removed trailing whitespace/empty lines at the end of the file for better code hygiene.

### Verification
- [x] Package version verified in `package.json`.
- [x] Runner script functionality remains unchanged.