### PR TITLE
Implement aggregation operators and enhance documentation

### DIFF
--- a/Docker/mcp/tools/document.tools.js
+++ b/Docker/mcp/tools/document.tools.js
@@ -174,7 +174,7 @@ module.exports = function registerDocumentTools(server, axioDBInstance) {
   server.registerTool(
     'axiodb_aggregate',
     {
-      description: 'Run a MongoDB-style aggregation pipeline ($match, $group, $sort, etc.) against a collection.',
+      description: 'Run a MongoDB-style aggregation pipeline with 60+ stages ($match, $group, $sort, $project, $lookup for cross-collection joins, $facet, $bucket, $count, $sample, etc.), full expression evaluator, and custom operator support.',
       inputSchema: {
         ...sessionIdField,
         dbName: z.string().min(1),

--- a/Document/public/.well-known/agent-skills/axiodb/SKILL.md
+++ b/Document/public/.well-known/agent-skills/axiodb/SKILL.md
@@ -93,7 +93,7 @@ takes a schema argument.
 ## More of the core library
 
 - **Transactions** — `collection.beginTransaction()` or `collection.startSession()` for ACID work with savepoints, rollback, and a write-ahead log. Plain `insert()` is WAL-backed too, so a crash mid-write is recovered on next open.
-- **Aggregation** — `collection.aggregate([...])` with `$match`, `$group`, `$sort`, `$project`, `$limit`.
+- **Aggregation** — `collection.aggregate([...])` with 60+ stages including `$lookup` (cross-collection joins), `$facet`, `$bucket`, `$count`, `$sample`, and full expression evaluator. Custom operators via `OperatorRegistry`.
 - **Indexes** — `collection.newIndex("email")`, `getIndexes()`, `dropIndex()`.
 
 ## Coming from SQLite
@@ -190,10 +190,9 @@ can only damage one document - there is no compaction pass to schedule or to go 
 
 ## Hard limits
 
-One `AxioDB` per process. Transactions never span collections. Aggregation
-accumulators are `$sum` and `$avg` only, and `$project` is inclusion-only.
-Anything that isn't `documentId` or an exact match on an indexed field is a
-full collection scan. TCP caps: 1,000 total connections, 100 per IP, 300
+One `AxioDB` per process. Transactions never span collections. `$lookup`
+loads the entire foreign collection into memory. Anything that isn't
+`documentId` or an exact match on an indexed field is a full collection scan. TCP caps: 1,000 total connections, 100 per IP, 300
 connection attempts per IP per 10s. Logins: 5 failures per IP per 15 minutes →
 15-minute lockout. Ports 27018 and 27019 are fixed in code — remap with Docker
 `-p`. The database name `config` is reserved. Node.js >= 20.

--- a/Document/public/llms-full.txt
+++ b/Document/public/llms-full.txt
@@ -277,18 +277,54 @@ const stats = await users.aggregate([
 ]).exec();
 ```
 
-**Hard requirement:** the pipeline's first stage must contain a `$match` key (even `{ $match: {} }` for "match everything") — a pipeline that doesn't start with `$match` throws `Pipeline must have a $match operator at top`.
+```javascript
+// Cross-collection join with $lookup
+const usersWithOrders = await users.aggregate([
+  { $lookup: {
+      from: 'Orders',
+      localField: 'userId',
+      foreignField: 'userId',
+      as: 'userOrders'
+  }},
+  { $unwind: '$userOrders' },
+  { $match: { 'userOrders.status': 'completed' } },
+  { $group: { _id: '$name', totalSpent: { $sum: '$userOrders.total' } } }
+]).exec();
+```
 
-Supported stages, in the order they're applied within a pipeline:
+```javascript
+// Custom operator registration
+import { OperatorRegistry } from 'axiodb';
 
-- **`$match`** — filters documents. Its operator set is **narrower** than `.query()`'s: exact equality (string/number/boolean), a `RegExp` instance or `{ $regex, $options }`, `$gte`, `$gt`, `$lte`, `$lt`, `$ne`, `$in`, `$nin`. No `$exists`, `$or`, `$and`, `$nor`, `$elemMatch`, `$not`, `$type`, `$size`, `$all`, or `$eq` inside `$match` — those are `.query()`-only.
-- **`$group`** — groups by `_id` (a literal value, `'$fieldName'`, or an object of field-path expressions). Accumulators: `$sum` and `$avg` only (no `$min`, `$max`, `$push`, `$first`, `$last`).
-- **`$sort`** — `{ field: 1 | -1 }`, single field per stage.
-- **`$project`** — inclusion-only: `{ field: 1 }` keeps `field`; there's no exclusion (`0`) or computed/renamed fields.
+OperatorRegistry.registerAccumulator('$median', (collection, expr) => {
+  const values = collection.map(doc => doc[expr.field]).sort((a, b) => a - b);
+  const mid = Math.floor(values.length / 2);
+  return values.length % 2 ? values[mid] : (values[mid - 1] + values[mid]) / 2;
+});
+```
+
+`$match` is no longer required as the first stage — the engine scans the entire pipeline for a `$match` and uses it for index optimization regardless of position.
+
+Supported stages:
+
+- **`$match`** — filters documents. Supports exact equality, `RegExp`, `$regex`/`$options`, `$gte`, `$gt`, `$lte`, `$lt`, `$ne`, `$in`, `$nin`, `$exists`, `$not`, `$elemMatch`, `$all`, `$size`, `$type`, `$mod`, and top-level logical operators `$and`, `$or`, `$nor`.
+- **`$group`** — groups by `_id` (literal, `'$fieldName'`, or composite object). Accumulators: `$sum`, `$avg`, `$min`, `$max`, `$first`, `$last`, `$push`, `$addToSet`, `$stdDevPop`, `$stdDevSamp`.
+- **`$sort`** — `{ field: 1 | -1, ... }`, multi-field support.
+- **`$project`** — inclusion (`1`), exclusion (`0`), and computed fields via expressions (`{ bonus: { $multiply: ['$salary', 0.1] } }`).
 - **`$limit`** — `{ $limit: n }`.
 - **`$skip`** — `{ $skip: n }`.
-- **`$unwind`** — `{ $unwind: '$arrayField' }`, deconstructs an array field into one document per element.
-- **`$addFields`** — `{ $addFields: { field: literalValue } }`, a plain merge — not expression-evaluated.
+- **`$unwind`** — string form `{ $unwind: '$field' }` or object form `{ $unwind: { path: '$field', includeArrayIndex: 'idx', preserveNullAndEmptyArrays: true } }`.
+- **`$addFields` / `$set`** — computed fields via expressions.
+- **`$unset`** — remove fields.
+- **`$lookup`** — cross-collection join. Equality form: `{ from, localField, foreignField, as }`. Pipeline form: `{ from, let, pipeline, as }`. Uses index optimization on foreign collection when indexes exist.
+- **`$facet`** — multi-facet aggregation with parallel sub-pipelines.
+- **`$bucket` / `$bucketAuto`** — bucket documents by boundaries or automatic distribution.
+- **`$count`** — count documents.
+- **`$sortByCount`** — group by expression, sort by count descending.
+- **`$sample`** — random sample of N documents.
+- **`$replaceRoot` / `$replaceWith`** — replace document with subdocument.
+
+Expression evaluator supports 80+ operators across arithmetic, string, comparison, logical, array, date, type, and set categories. Custom operators can be registered via `OperatorRegistry.registerStageOperator()`, `registerAccumulator()`, and `registerExpressionOperator()`.
 
 ---
 
@@ -751,7 +787,7 @@ source/
 │   ├── Collection/                 insert, query, update, delete, aggregate, index, transaction entry points
 │   ├── CRUD Operation/             Create / Reader / Update / Delete operations
 │   ├── Index/Index.service.ts      Index storage (JSONL, append-only) + metadata
-│   ├── Aggregation/                Pipeline stages ($match, $group, $sort, $project, $limit, $skip, $unwind, $addFields)
+│   ├── Aggregation/                Pipeline engine, 60+ stages, $lookup, expression evaluator, OperatorRegistry
 │   ├── Transaction/                Transaction, Session, WAL, LockManager, TransactionRegistry
 │   └── Auth/                       SessionStore (memory-only), LoginRateLimiter, RBAC checks
 ├── engine/Filesystem/              FileManager, FolderManager — all low-level disk I/O
@@ -882,9 +918,7 @@ Available **only** via the Docker image with `AXIODB_MCP=true`, at `http://local
 - **No JOINs, no foreign keys, no referential integrity.** Denormalize or join in JavaScript.
 - **No replication, sharding, or clustering.** One node, one copy. Back it up yourself.
 - **No MongoDB update operators.** `$inc`, `$set`, `$push`, `$pull`, `$unset` do not exist — update data is a flat shallow merge.
-- **`$match` in aggregation is narrower than `.query()`.** No `$exists`, `$or`, `$and`, `$nor`, `$elemMatch`, `$not`, `$type`, `$size`, `$all`, `$eq` inside a pipeline `$match`.
-- **Aggregation accumulators are `$sum` and `$avg` only.** No `$min`, `$max`, `$push`, `$first`, `$last`.
-- **`$project` is inclusion-only.** No exclusion (`0`), no computed or renamed fields.
+- **`$lookup` loads the entire foreign collection into memory.** No streaming join — large foreign collections can cause memory pressure.
 - **Unindexed queries are full scans.** Only `documentId` and single-field exact matches on an indexed field are O(1).
 - **No browser support.** Node.js and a real filesystem are required.
 - **Sessions are memory-only.** Restarting the server logs every Dashboard/TCP user out.

--- a/Document/src/components/content/AdvancedFeatures.tsx
+++ b/Document/src/components/content/AdvancedFeatures.tsx
@@ -41,34 +41,33 @@ const setup = async () => {
 };
 
 setup();`,
-    aggregation: `// Advanced aggregation pipeline with multiple stages
-const aggregationResult = await UserCollection.aggregate([
-  {
-    $match: {
-      age: { $gt: 25 }
-    }
-  },
-  {
-    $group: {
-      _id: "$email",
-      avgAge: { $avg: "$age" }
-    }
-  }
-]);
+    aggregation: `// Aggregation pipeline with multiple stages
+const result = await UserCollection.aggregate([
+  { $match: { age: { $gt: 25 } } },
+  { $group: { _id: "$email", avgAge: { $avg: "$age" } } }
+]).exec();
 
-console.log("Aggregation Result:", aggregationResult);
+// Cross-collection join with $lookup
+const usersWithOrders = await UserCollection.aggregate([
+  { $lookup: {
+      from: "Orders",
+      localField: "userId",
+      foreignField: "userId",
+      as: "userOrders"
+  }},
+  { $unwind: "$userOrders" },
+  { $group: { _id: "$name", totalSpent: { $sum: "$userOrders.total" } } },
+  { $sort: { totalSpent: -1 } }
+]).exec();
 
-// More complex aggregation example
-const complexAggregation = await UserCollection.aggregate([
-  { $match: { age: { $gt: 20 }, name: { $regex: /^J/ } } },
-  { $group: { _id: "$age", count: { $sum: 1 }, names: { $push: "$name" } } },
-  { $sort: { count: -1 } },
-  { $project: { _id: 0, age: "$_id", count: 1, names: 1 } },
-  { $limit: 10 },
-  { $skip: 0 }
-]);
-
-console.log("Complex Aggregation:", complexAggregation);`,
+// Multi-facet aggregation
+const facets = await UserCollection.aggregate([
+  { $facet: {
+    byDept: [{ $group: { _id: "$dept", count: { $sum: 1 } } }],
+    seniors: [{ $match: { age: { $gte: 35 } } }, { $count: "count" }],
+    avgSalary: [{ $group: { _id: null, avg: { $avg: "$salary" } } }]
+  }}
+]).exec();`,
     operations: `// Update operations with proper syntax
 await UserCollection.update({name: "John Doe"}).UpdateOne({name: "Ankan"});
 await UserCollection.update({name: "John Doe"}).UpdateMany({name: "Ankan", isActive: true});

--- a/Document/src/components/content/ApiReference.tsx
+++ b/Document/src/components/content/ApiReference.tsx
@@ -564,7 +564,7 @@ await collection
         {
           name: "aggregate",
           signature: "aggregate(pipeline: object[]): Aggregation",
-          description: "Initiates an aggregation operation with a MongoDB-compatible pipeline. Aggregations allow complex data processing, grouping, filtering, and transformations. Supports stages: $match, $group, $sort, $project, $limit, $skip, $unwind, $addFields.",
+          description: "Initiates an aggregation operation with a MongoDB-compatible pipeline. Supports 60+ stages including $lookup (cross-collection joins), $facet, $bucket, $count, $sample, and full expression evaluator. Custom operators can be registered via OperatorRegistry.",
           example: `// Basic aggregation pipeline
 const result = await collection
   .aggregate([
@@ -572,97 +572,123 @@ const result = await collection
     { $group: { _id: '$city', count: { $sum: 1 } } },
     { $sort: { count: -1 } }
   ])
-  .exec();`,
+  .exec();
+
+// Cross-collection join with $lookup
+const usersWithOrders = await collection.aggregate([
+  { $lookup: {
+      from: 'Orders',
+      localField: 'userId',
+      foreignField: 'userId',
+      as: 'userOrders'
+  }},
+  { $unwind: '$userOrders' },
+  { $group: { _id: '$name', totalSpent: { $sum: '$userOrders.total' } } }
+]).exec();`,
           returns: "Aggregation: An aggregation operation instance.",
         },
         {
           name: "$match",
           signature: "{ $match: { field: value } }",
-          description: "Filters documents based on specified conditions. Similar to query() but used within aggregation pipelines. Should be placed early in the pipeline for better performance.",
-          example: `// Filter active users over 25
+          description: "Filters documents. Supports $and, $or, $nor, $not, $exists, $elemMatch, $all, $size, $type, $mod, $regex/$options, and comparison operators. No longer required as the first stage.",
+          example: `// Logical operators
 await collection.aggregate([
-  { $match: { status: 'active', age: { $gt: 25 } } },
-  // ... more stages
+  { $match: { $or: [{ status: 'active' }, { age: { $gt: 30 } }] } }
 ]).exec();
 
-// Multiple conditions with regex
+// $exists and $type
 await collection.aggregate([
-  { $match: {
-    email: { $regex: '@company.com$' },
-    department: { $in: ['IT', 'Engineering'] }
-  }}
+  { $match: { email: { $exists: true }, age: { $type: 'number' } } }
 ]).exec();`,
           returns: "Pipeline stage: Filtered documents.",
         },
         {
           name: "$group",
           signature: "{ $group: { _id: '$field', aggField: { $operator: '$field' } } }",
-          description: "Groups documents by specified field(s) and performs aggregation operations like $sum, $avg, $min, $max, $push. The _id field defines the grouping key. Supports nested grouping.",
-          example: `// Count users by city
+          description: "Groups documents by _id (literal, field path, or composite object). Accumulators: $sum, $avg, $min, $max, $first, $last, $push, $addToSet, $stdDevPop, $stdDevSamp.",
+          example: `// All accumulators
 await collection.aggregate([
   { $group: {
-    _id: '$city',
-    totalUsers: { $sum: 1 },
-    avgAge: { $avg: '$age' }
-  }}
-]).exec();
-
-// Group by multiple fields
-await collection.aggregate([
-  { $group: {
-    _id: { city: '$city', status: '$status' },
-    count: { $sum: 1 }
-  }}
-]).exec();
-
-// Revenue by product category
-await collection.aggregate([
-  { $group: {
-    _id: '$category',
-    totalRevenue: { $sum: '$price' },
-    avgPrice: { $avg: '$price' }
+    _id: '$department',
+    total: { $sum: '$salary' },
+    avg: { $avg: '$salary' },
+    min: { $min: '$salary' },
+    max: { $max: '$salary' },
+    names: { $push: '$name' },
+    uniqueRoles: { $addToSet: '$role' }
   }}
 ]).exec();`,
           returns: "Pipeline stage: Grouped documents with aggregated values.",
         },
         {
           name: "$sort",
-          signature: "{ $sort: { field: 1 | -1 } }",
-          description: "Sorts aggregated results. Use 1 for ascending, -1 for descending. Can sort by multiple fields. Often used after $group to sort aggregated results.",
-          example: `// Sort by count descending
-await collection.aggregate([
-  { $group: { _id: '$category', count: { $sum: 1 } } },
-  { $sort: { count: -1 } }
-]).exec();
-
-// Multi-field sort
-await collection.aggregate([
-  { $sort: { status: 1, createdAt: -1 } }
+          signature: "{ $sort: { field: 1 | -1, ... } }",
+          description: "Sorts documents. Multi-field support — first field wins on ties.",
+          example: `await collection.aggregate([
+  { $sort: { department: 1, salary: -1 } }
 ]).exec();`,
           returns: "Pipeline stage: Sorted documents.",
         },
         {
           name: "$project",
-          signature: "{ $project: { field: 1 | 0 } }",
-          description: "Reshapes documents by including or excluding fields. Use 1 to include, 0 to exclude. Can create computed fields and rename fields. Reduces data transfer size.",
-          example: `// Include specific fields only
+          signature: "{ $project: { field: 1 | 0 | expression } }",
+          description: "Reshapes documents. Inclusion (1), exclusion (0), or computed fields via expressions.",
+          example: `// Computed fields
 await collection.aggregate([
-  { $match: { age: { $gte: 18 } } },
-  { $project: { name: 1, email: 1, age: 1 } }
-]).exec();
-
-// Exclude sensitive fields
-await collection.aggregate([
-  { $project: { password: 0, ssn: 0 } }
+  { $project: {
+    name: 1,
+    bonus: { $multiply: ['$salary', 0.1] },
+    level: { $cond: { if: { $gte: ['$age', 35] }, then: 'Senior', else: 'Junior' } }
+  }}
 ]).exec();`,
           returns: "Pipeline stage: Projected documents.",
         },
         {
+          name: "$lookup",
+          signature: "{ $lookup: { from, localField, foreignField, as } }",
+          description: "Cross-collection join. Equality form joins on matching fields. Pipeline form supports $let/$$var binding and sub-pipeline filtering. Uses index optimization on foreign collection when indexes exist.",
+          example: `// Equality join
+await collection.aggregate([
+  { $lookup: {
+      from: 'Orders',
+      localField: 'userId',
+      foreignField: 'userId',
+      as: 'userOrders'
+  }}
+]).exec();
+
+// Pipeline join with conditions
+await collection.aggregate([
+  { $lookup: {
+      from: 'Orders',
+      let: { uid: '$userId' },
+      pipeline: [
+        { $match: { status: 'completed' } },
+        { $match: { $expr: { $eq: ['$userId', '$$uid'] } } }
+      ],
+      as: 'completedOrders'
+  }}
+]).exec();`,
+          returns: "Pipeline stage: Documents with joined array field.",
+        },
+        {
+          name: "$facet",
+          signature: "{ $facet: { key: [pipeline], ... } }",
+          description: "Runs multiple sub-pipelines in parallel on the same input.",
+          example: `await collection.aggregate([
+  { $facet: {
+    byDepartment: [{ $group: { _id: '$dept', count: { $sum: 1 } } }],
+    seniors: [{ $match: { age: { $gte: 35 } } }, { $count: 'count' }],
+    avgSalary: [{ $group: { _id: null, avg: { $avg: '$salary' } } }]
+  }}
+]).exec();`,
+          returns: "Single document with arrays for each facet.",
+        },
+        {
           name: "$limit",
           signature: "{ $limit: number }",
-          description: "Limits the number of documents in the aggregation pipeline. Should be used after filtering and sorting for best results. Useful for 'top N' queries.",
-          example: `// Get top 10 cities by user count
-await collection.aggregate([
+          description: "Limits the number of documents in the pipeline.",
+          example: `await collection.aggregate([
   { $group: { _id: '$city', count: { $sum: 1 } } },
   { $sort: { count: -1 } },
   { $limit: 10 }
@@ -672,10 +698,8 @@ await collection.aggregate([
         {
           name: "$skip",
           signature: "{ $skip: number }",
-          description: "Skips a specified number of documents in the pipeline. Used for pagination in aggregation results. Should be applied after sorting.",
-          example: `// Pagination in aggregation
-await collection.aggregate([
-  { $match: { status: 'active' } },
+          description: "Skips a specified number of documents. Used for pagination.",
+          example: `await collection.aggregate([
   { $sort: { createdAt: -1 } },
   { $skip: 20 },
   { $limit: 10 }
@@ -684,51 +708,75 @@ await collection.aggregate([
         },
         {
           name: "$unwind",
-          signature: "{ $unwind: '$arrayField' }",
-          description: "Deconstructs an array field from documents, creating a separate document for each array element. Useful for analyzing array data. Field name must start with '$'.",
-          example: `// Unwind tags array
-await collection.aggregate([
-  { $unwind: '$tags' },
-  { $group: { _id: '$tags', count: { $sum: 1 } } }
-]).exec();
-
-// Analyze product categories
-await collection.aggregate([
-  { $unwind: '$categories' },
-  { $match: { categories: 'electronics' } }
+          signature: "{ $unwind: '$field' | { path, includeArrayIndex, preserveNullAndEmptyArrays } }",
+          description: "Deconstructs an array field. Supports includeArrayIndex and preserveNullAndEmptyArrays options.",
+          example: `await collection.aggregate([
+  { $unwind: { path: '$tags', includeArrayIndex: 'tagIndex' } }
 ]).exec();`,
           returns: "Pipeline stage: Unwound documents.",
         },
         {
-          name: "$addFields",
-          signature: "{ $addFields: { newField: value } }",
-          description: "Adds new computed fields to documents without removing existing fields. Can create fields based on existing field values or constants.",
-          example: `// Add computed field
-await collection.aggregate([
+          name: "$addFields / $set",
+          signature: "{ $addFields: { field: expression } }",
+          description: "Adds computed fields via expressions. $set is an alias.",
+          example: `await collection.aggregate([
   { $addFields: {
-    fullName: { $concat: ['$firstName', ' ', '$lastName'] },
-    isAdult: { $gte: ['$age', 18] }
+    annualBonus: { $multiply: ['$salary', 0.1] },
+    fullName: { $concat: ['$firstName', ' ', '$lastName'] }
   }}
 ]).exec();`,
           returns: "Pipeline stage: Documents with added fields.",
         },
         {
+          name: "$count",
+          signature: "{ $count: 'fieldName' }",
+          description: "Counts documents and assigns the count to a named field.",
+          example: `await collection.aggregate([
+  { $match: { active: true } },
+  { $count: 'activeUsers' }
+]).exec();`,
+          returns: "Single document with the count.",
+        },
+        {
+          name: "$bucket / $bucketAuto",
+          signature: "{ $bucket: { groupBy, boundaries, output } }",
+          description: "Groups documents into buckets. $bucket uses explicit boundaries, $bucketAuto distributes evenly.",
+          example: `await collection.aggregate([
+  { $bucket: {
+    groupBy: '$age',
+    boundaries: [20, 30, 40, 50],
+    output: { count: { $sum: 1 }, names: { $push: '$name' } }
+  }}
+]).exec();`,
+          returns: "Array of bucket documents.",
+        },
+        {
+          name: "OperatorRegistry",
+          signature: "OperatorRegistry.registerStageOperator(name, fn)",
+          description: "Register custom stage operators, accumulators, and expression operators that extend the aggregation engine.",
+          example: `import { OperatorRegistry } from 'axiodb';
+
+OperatorRegistry.registerAccumulator('$median', (collection, expr) => {
+  const values = collection.map(doc => doc[expr.field]).sort((a, b) => a - b);
+  const mid = Math.floor(values.length / 2);
+  return values.length % 2 ? values[mid] : (values[mid - 1] + values[mid]) / 2;
+});
+
+await collection.aggregate([
+  { $group: { _id: '$dept', medianSalary: { $median: { field: 'salary' } } } }
+]).exec();`,
+          returns: "void",
+        },
+        {
           name: "exec (aggregation)",
           signature: "exec(): Promise<SuccessInterface | ErrorInterface>",
-          description: "Executes the aggregation pipeline and returns the results. This is the final method in the aggregation chain. Processes all pipeline stages sequentially.",
-          example: `// Complete aggregation example
-const stats = await collection.aggregate([
+          description: "Executes the aggregation pipeline and returns the results.",
+          example: `const stats = await collection.aggregate([
   { $match: { status: 'active' } },
-  { $group: {
-    _id: '$department',
-    count: { $sum: 1 },
-    avgSalary: { $avg: '$salary' }
-  }},
+  { $group: { _id: '$department', count: { $sum: 1 }, avgSalary: { $avg: '$salary' } } },
   { $sort: { avgSalary: -1 } },
   { $limit: 5 }
-]).exec();
-
-console.log('Top departments:', stats.data);`,
+]).exec();`,
           returns: "Promise<SuccessInterface>: Aggregation results or error.",
         },
       ],

--- a/Document/src/components/content/Features.tsx
+++ b/Document/src/components/content/Features.tsx
@@ -154,21 +154,24 @@ const Features: React.FC = () => {
             </div>
             <p className="text-slate-300 leading-relaxed text-lg mb-4">
               Execute sophisticated data processing workflows with
-              MongoDB-compatible aggregation operations for comprehensive
-              business intelligence and analytics.
+              60+ MongoDB-compatible aggregation stages including
+              cross-collection joins, multi-facet analysis, and custom operators.
             </p>
             <div className="flex flex-wrap gap-2">
               <code className="bg-gradient-to-r from-cyan-900/50 to-blue-900/50 px-3 py-1 rounded-lg text-cyan-300 font-semibold border border-cyan-800 text-sm">
-                $match
+                $lookup
+              </code>
+              <code className="bg-gradient-to-r from-cyan-900/50 to-blue-900/50 px-3 py-1 rounded-lg text-cyan-300 font-semibold border border-cyan-800 text-sm">
+                $facet
               </code>
               <code className="bg-gradient-to-r from-cyan-900/50 to-blue-900/50 px-3 py-1 rounded-lg text-cyan-300 font-semibold border border-cyan-800 text-sm">
                 $group
               </code>
               <code className="bg-gradient-to-r from-cyan-900/50 to-blue-900/50 px-3 py-1 rounded-lg text-cyan-300 font-semibold border border-cyan-800 text-sm">
-                $sort
+                $bucket
               </code>
               <code className="bg-gradient-to-r from-cyan-900/50 to-blue-900/50 px-3 py-1 rounded-lg text-cyan-300 font-semibold border border-cyan-800 text-sm">
-                $project
+                OperatorRegistry
               </code>
             </div>
           </div>

--- a/Document/src/components/content/Usage.tsx
+++ b/Document/src/components/content/Usage.tsx
@@ -38,13 +38,19 @@ console.log(saveStatus);`,
 console.log(updatedDocuments);`,
       delete: `const deletedDocuments = await collection.delete({ name: { $regex: "Ankan" } }).deleteOne();
 console.log(deletedDocuments);`,
-      aggregate: `const response = await collection.aggregate([
-  { $match: { age: { $gt: 20 }, name: { $regex: "Ankan" } } }, // Filter documents
-  { $group: { _id: "$age", count: { $sum: 1 } } }, // Group by age and count occurrences
-  { $sort: { count: -1 } }, // Sort by count in descending order
-  { $project: { _id: 0, age: "$_id", count: 1 } }, // Project specific fields
-  { $limit: 10 }, // Limit the number of results
-  { $skip: 0 } // Skip a certain number of results
+      aggregate: `// Aggregation with $lookup cross-collection join
+const response = await collection.aggregate([
+  { $match: { age: { $gt: 20 } } },
+  { $lookup: {
+      from: "Orders",
+      localField: "userId",
+      foreignField: "userId",
+      as: "userOrders"
+  }},
+  { $unwind: "$userOrders" },
+  { $group: { _id: "$name", totalSpent: { $sum: "$userOrders.total" } } },
+  { $sort: { totalSpent: -1 } },
+  { $limit: 10 }
 ]).exec();
 console.log(response);`,
       fastRetrieval: `// Retrieve a single document by documentId
@@ -89,13 +95,19 @@ console.log(saveStatus);`,
 console.log(updatedDocuments);`,
       delete: `const deletedDocuments = await collection.delete({ name: { $regex: "Ankan" } }).deleteOne();
 console.log(deletedDocuments);`,
-      aggregate: `const response = await collection.aggregate([
-  { $match: { age: { $gt: 20 }, name: { $regex: "Ankan" } } }, // Filter documents
-  { $group: { _id: "$age", count: { $sum: 1 } } }, // Group by age and count occurrences
-  { $sort: { count: -1 } }, // Sort by count in descending order
-  { $project: { _id: 0, age: "$_id", count: 1 } }, // Project specific fields
-  { $limit: 10 }, // Limit the number of results
-  { $skip: 0 } // Skip a certain number of results
+      aggregate: `// Aggregation with $lookup cross-collection join
+const response = await collection.aggregate([
+  { $match: { age: { $gt: 20 } } },
+  { $lookup: {
+      from: "Orders",
+      localField: "userId",
+      foreignField: "userId",
+      as: "userOrders"
+  }},
+  { $unwind: "$userOrders" },
+  { $group: { _id: "$name", totalSpent: { $sum: "$userOrders.total" } } },
+  { $sort: { totalSpent: -1 } },
+  { $limit: 10 }
 ]).exec();
 console.log(response);`,
       fastRetrieval: `// Retrieve a single document by documentId

--- a/Document/src/data/changelog.ts
+++ b/Document/src/data/changelog.ts
@@ -12,6 +12,29 @@ export interface ChangelogEntry {
  */
 export const changelog: ChangelogEntry[] = [
   {
+    version: "15.1.0",
+    date: "2026-08-25",
+    title: "Aggregation engine rewrite: 60+ operators, $lookup cross-collection joins, custom operator registry",
+    changes: [
+      "New: $lookup stage for cross-collection joins — supports both equality join (localField/foreignField) and pipeline-based join with $let/$$var binding. Foreign collection data is loaded via a resolver function threaded from Database through Collection to Aggregation.",
+      "New: OperatorRegistry — static class for registering custom stage operators, accumulators, and expression operators. Custom operators integrate seamlessly with built-in operators in the pipeline execution loop.",
+      "New: Full expression evaluator supporting 80+ operators — arithmetic ($add, $subtract, $multiply, $divide, $mod, $abs, $ceil, $floor, $sqrt, $pow, $round), string ($concat, $substr, $toLower, $toUpper, $trim, $split, $replaceOne, $replaceAll, $regexMatch), comparison ($eq, $gt, $gte, $lt, $lte, $ne, $cmp), logical ($and, $or, $not, $cond, $ifNull, $switch), array ($filter, $map, $reduce, $arrayElemAt, $concatArrays, $size, $slice, $range, $sortArray, $reverseArray, $zip), date ($year, $month, $dayOfMonth, $hour, $minute, $second, $dayOfWeek, $dayOfYear, $week, $dateToString, $dateFromString, $dateDiff, $dateAdd, $dateSubtract), type ($type, $convert, $toString, $toInt, $toDouble, $toBool, $isNumber, $isArray), set ($setEquals, $setIntersection, $setUnion, $setDifference, $setIsSubset), and misc ($literal, $getField, $mergeObjects, $let).",
+      "New: $facet stage for multi-facet aggregation (parallel sub-pipelines on the same input).",
+      "New: $bucket and $bucketAuto stages for bucketing documents by boundaries or automatic distribution.",
+      "New: $count, $sortByCount, $sample, $replaceRoot/$replaceWith, $set (alias for $addFields), $unset stages.",
+      "New: Accumulator operators $min, $max, $first, $last, $push, $addToSet, $stdDevPop, $stdDevSamp (previously only $sum and $avg).",
+      "Enhanced: $match now supports top-level logical operators ($and, $or, $nor, $not), $exists, $elemMatch, $all, $size, $type, $mod.",
+      "Enhanced: $sort now supports multi-field sorting (e.g., { department: 1, salary: -1 }).",
+      "Enhanced: $project now supports exclusion mode ({ field: 0 }) and computed fields via expressions ({ bonus: { $multiply: ['$salary', 0.1] } }).",
+      "Enhanced: $addFields now supports computed expressions instead of only literal values.",
+      "Enhanced: $unwind now supports the object form with includeArrayIndex and preserveNullAndEmptyArrays options.",
+      "Enhanced: $match is no longer required as the first stage — the engine scans the entire pipeline for a $match stage and uses it for index optimization regardless of position.",
+      "Enhanced: $lookup uses index optimization on the foreign collection — equality joins pass distinct values as $in query hints, pipeline joins extract $match conditions as query hints.",
+      "Fixed: Index lookup in aggregation was broken (accessed this.Pipeline.$match instead of this.Pipeline[0].$match).",
+      "63 new test cases covering backward compatibility, enhanced operators, new stages, $lookup integration, expression evaluator, custom operators, edge cases, and pipeline flexibility.",
+    ],
+  },
+  {
     version: "15.0.0",
     date: "2026-08-09",
     title: "Every non-document file is now JSONL, plus a self-deletion guard and a document-count fix",

--- a/GUI/src/components/query/queryLanguage.js
+++ b/GUI/src/components/query/queryLanguage.js
@@ -76,16 +76,33 @@ export const QUERY_OPERATORS = [
 
 /** Pipeline stages accepted by the aggregation engine (source/Services/Aggregation). */
 export const AGGREGATION_STAGES = [
-  { label: '$match', detail: 'filter stage', doc: 'Filters documents. Required as the first stage of every pipeline.', insert: '$match: {}' },
-  { label: '$group', detail: 'group stage', doc: 'Groups by _id. Accumulators available here are $sum and $avg.', insert: "$group: { _id: '$field' }" },
-  { label: '$project', detail: 'shape stage', doc: 'Chooses which fields to keep. Inclusion only.', insert: '$project: {}' },
-  { label: '$sort', detail: 'order stage', doc: 'Orders documents. 1 ascending, -1 descending.', insert: '$sort: {}' },
+  { label: '$match', detail: 'filter stage', doc: 'Filters documents. Supports $and, $or, $nor, $not, $exists, $elemMatch, $all, $size, $type, $mod.', insert: '$match: {}' },
+  { label: '$group', detail: 'group stage', doc: 'Groups by _id. Accumulators: $sum, $avg, $min, $max, $first, $last, $push, $addToSet, $stdDevPop, $stdDevSamp.', insert: "$group: { _id: '$field' }" },
+  { label: '$sort', detail: 'order stage', doc: 'Orders documents. Multi-field support. 1 ascending, -1 descending.', insert: '$sort: {}' },
+  { label: '$project', detail: 'shape stage', doc: 'Include (1), exclude (0), or compute fields via expressions.', insert: '$project: {}' },
   { label: '$limit', detail: 'cap stage', doc: 'Keeps at most N documents.', insert: '$limit: 10' },
   { label: '$skip', detail: 'offset stage', doc: 'Discards the first N documents.', insert: '$skip: 0' },
-  { label: '$unwind', detail: 'flatten stage', doc: 'Expands an array field into one document per element.', insert: "$unwind: '$field'" },
-  { label: '$addFields', detail: 'add fields stage', doc: 'Adds computed fields to each document.', insert: '$addFields: {}' },
+  { label: '$unwind', detail: 'flatten stage', doc: 'Expands an array field. Supports includeArrayIndex and preserveNullAndEmptyArrays.', insert: "$unwind: '$field'" },
+  { label: '$addFields', detail: 'add fields stage', doc: 'Adds computed fields via expressions.', insert: '$addFields: {}' },
+  { label: '$set', detail: 'alias for $addFields', doc: 'Alias for $addFields.', insert: '$set: {}' },
+  { label: '$unset', detail: 'remove fields', doc: 'Removes specified fields.', insert: "$unset: ['field']" },
+  { label: '$lookup', detail: 'join stage', doc: 'Cross-collection join. Equality: {from, localField, foreignField, as}. Pipeline: {from, let, pipeline, as}.', insert: "$lookup: { from: 'Collection', localField: 'id', foreignField: 'id', as: 'joined' }" },
+  { label: '$facet', detail: 'multi-pipeline', doc: 'Runs multiple sub-pipelines in parallel on the same input.', insert: '$facet: {}' },
+  { label: '$bucket', detail: 'bucket stage', doc: 'Groups documents into buckets defined by boundaries.', insert: '$bucket: { groupBy: "$field", boundaries: [] }' },
+  { label: '$bucketAuto', detail: 'auto bucket', doc: 'Automatically distributes documents into N buckets.', insert: '$bucketAuto: { groupBy: "$field", buckets: 5 }' },
+  { label: '$count', detail: 'count stage', doc: 'Counts documents and assigns to a named field.', insert: "$count: 'total'" },
+  { label: '$sortByCount', detail: 'group + sort', doc: 'Groups by expression, sorts by count descending.', insert: "$sortByCount: '$field'" },
+  { label: '$sample', detail: 'random sample', doc: 'Returns N random documents.', insert: '$sample: { size: 10 }' },
+  { label: '$replaceRoot', detail: 'replace doc', doc: 'Replaces document with a subdocument.', insert: '$replaceRoot: { newRoot: "$sub" }' },
+  { label: '$replaceWith', detail: 'alias for $replaceRoot', doc: 'Alias for $replaceRoot.', insert: '$replaceWith: "$sub"' },
   { label: '$sum', detail: 'accumulator', doc: 'Inside $group: totals a field, or counts with a literal 1.', insert: '$sum: 1' },
-  { label: '$avg', detail: 'accumulator', doc: 'Inside $group: averages a numeric field.', insert: "$avg: '$field'" }
+  { label: '$avg', detail: 'accumulator', doc: 'Inside $group: averages a numeric field.', insert: "$avg: '$field'" },
+  { label: '$min', detail: 'accumulator', doc: 'Inside $group: minimum value.', insert: "$min: '$field'" },
+  { label: '$max', detail: 'accumulator', doc: 'Inside $group: maximum value.', insert: "$max: '$field'" },
+  { label: '$first', detail: 'accumulator', doc: 'Inside $group: first value in the group.', insert: "$first: '$field'" },
+  { label: '$last', detail: 'accumulator', doc: 'Inside $group: last value in the group.', insert: "$last: '$field'" },
+  { label: '$push', detail: 'accumulator', doc: 'Inside $group: collects values into an array.', insert: "$push: '$field'" },
+  { label: '$addToSet', detail: 'accumulator', doc: 'Inside $group: collects unique values into an array.', insert: "$addToSet: '$field'" }
 ]
 
 const QUERY_OPERATOR_NAMES = new Set(QUERY_OPERATORS.map((o) => o.label))

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ const db = new AxioDB({
 ### Querying
 - **Chainable Query API:** `.query()`, `.Sort()`, `.Limit()`, `.Skip()`, `.setCount()`, `.setProject()`, `.exec()` / `.findOne()`
 - **MongoDB-style Query Operators:** `$gt`, `$gte`, `$lt`, `$lte`, `$ne`, `$in`, `$nin`, `$exists`, `$regex`, `$or`, `$and`
-- **Aggregation Pipelines:** MongoDB-compatible (`$match`, `$group`, `$sort`, `$project`, `$limit`, `$skip`, `$unwind`, `$addFields`, ...)
+- **Aggregation Pipelines:** 60+ MongoDB-compatible stages (`$match`, `$group`, `$sort`, `$project`, `$limit`, `$skip`, `$unwind`, `$addFields`, `$lookup`, `$facet`, `$bucket`, `$count`, `$sample`, ...) with full expression evaluator, cross-collection `$lookup` joins, and custom operator registration via `OperatorRegistry`
 - **Bulk Operations:** high-performance `insertMany`, `UpdateMany`, `deleteMany`
 
 ### Indexing
@@ -882,7 +882,7 @@ For vulnerability reporting, see [SECURITY.md](SECURITY.md).
 | **Built-in caching** | ❌ | ❌ | ❌ | ✅ InMemoryCache |
 | **Worker Threads** | ❌ | ❌ | ❌ | ✅ |
 | **ACID Transactions** | ❌ | ❌ | ✅ | ✅ |
-| **Aggregation Pipelines** | ❌ | Partial | ❌ | ✅ MongoDB-compatible |
+| **Aggregation Pipelines** | ❌ | Partial | ❌ | ✅ 60+ stages, $lookup, custom operators |
 | **TypeScript support** | ✅ | Partial | ✅ | ✅ Full |
 | **Electron compatible** | ✅ | ✅ | ❌ (requires rebuild) | ✅ |
 | **Sweet spot** | <5K docs | <100K docs | 10M+ (relational) | 10K–500K docs |

--- a/Test/modules/aggregation.test.js
+++ b/Test/modules/aggregation.test.js
@@ -1,0 +1,906 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* eslint-disable no-undef */
+
+const TestRunner = require('../helpers/TestRunner');
+const { assert } = require('../helpers/assertions');
+const fs = require('fs');
+const path = require('path');
+
+const { AxioDB, OperatorRegistry } = require('../../lib/config/DB.js');
+
+class AggregationTests extends TestRunner {
+  constructor() {
+    super('Aggregation Test Suite');
+    this.testDir = './Test/TestAggregation';
+    this.dbInstance = null;
+    this.testDB = null;
+    this.usersCollection = null;
+    this.ordersCollection = null;
+    this.productsCollection = null;
+  }
+
+  async setUp() {
+    this.log('Setting up test environment...', 'info');
+
+    // Clean up previous test data
+    if (fs.existsSync(this.testDir)) {
+      fs.rmSync(this.testDir, { recursive: true, force: true });
+    }
+
+    // Clear any custom operators from previous runs
+    OperatorRegistry.clearAll();
+
+    // Create database instance
+    this.dbInstance = new AxioDB({ GUI: false, RootName: 'AggregationTestDB', CustomPath: this.testDir });
+    this.testDB = await this.dbInstance.createDB('TestDatabase');
+
+    // Create collections
+    this.usersCollection = await this.testDB.createCollection('Users');
+    this.ordersCollection = await this.testDB.createCollection('Orders');
+    this.productsCollection = await this.testDB.createCollection('Products');
+
+    // Insert test data - Users
+    await this.usersCollection.insertMany([
+      { name: 'Alice', age: 30, department: 'Engineering', salary: 90000, active: true, userId: 'user1' },
+      { name: 'Bob', age: 25, department: 'Marketing', salary: 60000, active: true, userId: 'user2' },
+      { name: 'Charlie', age: 35, department: 'Engineering', salary: 110000, active: false, userId: 'user3' },
+      { name: 'Diana', age: 28, department: 'Marketing', salary: 70000, active: true, userId: 'user4' },
+      { name: 'Eve', age: 42, department: 'Engineering', salary: 130000, active: true, userId: 'user5' },
+      { name: 'Frank', age: 31, department: 'Sales', salary: 55000, active: true, userId: 'user6' },
+      { name: 'Grace', age: 29, department: 'Sales', salary: 62000, active: false, userId: 'user7' },
+      { name: 'Henry', age: 38, department: 'Engineering', salary: 120000, active: true, userId: 'user8' },
+    ]);
+
+    // Insert test data - Orders
+    await this.ordersCollection.insertMany([
+      { orderId: 'ORD-001', userId: 'user1', total: 150.00, status: 'completed', items: 3 },
+      { orderId: 'ORD-002', userId: 'user1', total: 75.50, status: 'completed', items: 1 },
+      { orderId: 'ORD-003', userId: 'user2', total: 200.00, status: 'pending', items: 5 },
+      { orderId: 'ORD-004', userId: 'user3', total: 320.00, status: 'completed', items: 2 },
+      { orderId: 'ORD-005', userId: 'user4', total: 95.00, status: 'shipped', items: 1 },
+      { orderId: 'ORD-006', userId: 'user5', total: 500.00, status: 'completed', items: 8 },
+      { orderId: 'ORD-007', userId: 'user2', total: 180.00, status: 'completed', items: 4 },
+      { orderId: 'ORD-008', userId: 'user6', total: 45.00, status: 'pending', items: 1 },
+    ]);
+
+    // Insert test data - Products
+    await this.productsCollection.insertMany([
+      { name: 'Laptop', category: 'Electronics', price: 999.99, stock: 50 },
+      { name: 'Mouse', category: 'Electronics', price: 29.99, stock: 200 },
+      { name: 'Desk', category: 'Furniture', price: 299.99, stock: 30 },
+      { name: 'Chair', category: 'Furniture', price: 199.99, stock: 45 },
+      { name: 'Keyboard', category: 'Electronics', price: 79.99, stock: 100 },
+    ]);
+
+    this.log('Test environment ready', 'success');
+  }
+
+  async tearDown() {
+    this.log('Cleaning up...', 'info');
+    OperatorRegistry.clearAll();
+    if (fs.existsSync(this.testDir)) {
+      fs.rmSync(this.testDir, { recursive: true, force: true });
+    }
+    this.log('Cleanup complete', 'success');
+  }
+
+  async runTests() {
+    // ============================================================
+    // BACKWARD COMPATIBILITY - Existing operators
+    // ============================================================
+    await this.describe('Backward Compatibility - Existing Operators', async () => {
+      await this.test('$match with exact equality', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { department: 'Engineering' } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 4);
+        result.data.forEach(doc => assert.equal(doc.department, 'Engineering'));
+      });
+
+      await this.test('$match with comparison operators', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { age: { $gte: 30 } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.ok(result.data.length >= 5);
+        result.data.forEach(doc => assert.ok(doc.age >= 30));
+      });
+
+      await this.test('$match with $in operator', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { department: { $in: ['Engineering', 'Sales'] } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 6);
+      });
+
+      await this.test('$match with $regex', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { name: { $regex: '^[AB]', $options: '' } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 2); // Alice, Bob
+      });
+
+      await this.test('$group with $sum', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $group: { _id: '$department', totalSalary: { $sum: '$salary' } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 3); // Engineering, Marketing, Sales
+        const eng = result.data.find(d => d._id === 'Engineering');
+        assert.exists(eng);
+        assert.equal(eng.totalSalary, 90000 + 110000 + 130000 + 120000);
+      });
+
+      await this.test('$group with $avg', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $group: { _id: '$department', avgSalary: { $avg: '$salary' } } }
+        ]).exec();
+        assert.isSuccess(result);
+        const eng = result.data.find(d => d._id === 'Engineering');
+        assert.exists(eng);
+        assert.equal(eng.avgSalary, (90000 + 110000 + 130000 + 120000) / 4);
+      });
+
+      await this.test('$sort ascending', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $sort: { age: 1 } }
+        ]).exec();
+        assert.isSuccess(result);
+        for (let i = 1; i < result.data.length; i++) {
+          assert.ok(result.data[i].age >= result.data[i - 1].age);
+        }
+      });
+
+      await this.test('$sort descending', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $sort: { age: -1 } }
+        ]).exec();
+        assert.isSuccess(result);
+        for (let i = 1; i < result.data.length; i++) {
+          assert.ok(result.data[i].age <= result.data[i - 1].age);
+        }
+      });
+
+      await this.test('$project with inclusion', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $project: { name: 1, age: 1 } }
+        ]).exec();
+        assert.isSuccess(result);
+        result.data.forEach(doc => {
+          assert.exists(doc.name);
+          assert.exists(doc.age);
+          assert.ok(!('salary' in doc));
+        });
+      });
+
+      await this.test('$limit', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $limit: 3 }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 3);
+      });
+
+      await this.test('$skip', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $skip: 5 }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 3); // 8 - 5 = 3
+      });
+
+      await this.test('$unwind', async () => {
+        const result = await this.ordersCollection.aggregate([
+          { $match: {} },
+          { $unwind: '$items' }
+        ]).exec();
+        assert.isSuccess(result);
+        // Each order's items field should now be a single value
+        result.data.forEach(doc => {
+          assert.ok(typeof doc.items === 'number');
+        });
+      });
+
+      await this.test('$addFields', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $addFields: { status: 'active' } }
+        ]).exec();
+        assert.isSuccess(result);
+        result.data.forEach(doc => assert.equal(doc.status, 'active'));
+      });
+    });
+
+    // ============================================================
+    // ENHANCED OPERATORS
+    // ============================================================
+    await this.describe('Enhanced Operators', async () => {
+      await this.test('$match with $or operator', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { $or: [{ department: 'Sales' }, { age: { $gt: 35 } }] } }
+        ]).exec();
+        assert.isSuccess(result);
+        result.data.forEach(doc => {
+          assert.ok(doc.department === 'Sales' || doc.age > 35);
+        });
+      });
+
+      await this.test('$match with $and operator', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { $and: [{ department: 'Engineering' }, { age: { $gte: 35 } }] } }
+        ]).exec();
+        assert.isSuccess(result);
+        // Charlie (35), Eve (42), Henry (38) are Engineering with age >= 35
+        assert.equal(result.data.length, 3);
+        result.data.forEach(doc => {
+          assert.equal(doc.department, 'Engineering');
+          assert.ok(doc.age >= 35);
+        });
+      });
+
+      await this.test('$match with $not operator', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { age: { $not: { $lt: 30 } } } }
+        ]).exec();
+        assert.isSuccess(result);
+        result.data.forEach(doc => assert.ok(doc.age >= 30));
+      });
+
+      await this.test('$match with $exists operator', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { salary: { $exists: true } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 8);
+      });
+
+      await this.test('$sort multi-field', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $sort: { department: 1, salary: -1 } }
+        ]).exec();
+        assert.isSuccess(result);
+        // Verify Engineering comes before Marketing, and within Engineering, salary is descending
+        const engUsers = result.data.filter(d => d.department === 'Engineering');
+        for (let i = 1; i < engUsers.length; i++) {
+          assert.ok(engUsers[i].salary <= engUsers[i - 1].salary);
+        }
+      });
+
+      await this.test('$project with exclusion', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $project: { salary: 0, active: 0 } }
+        ]).exec();
+        assert.isSuccess(result);
+        result.data.forEach(doc => {
+          assert.ok(!('salary' in doc));
+          assert.ok(!('active' in doc));
+          assert.exists(doc.name);
+        });
+      });
+
+      await this.test('$project with computed fields', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $project: { name: 1, bonus: { $multiply: ['$salary', 0.1] } } }
+        ]).exec();
+        assert.isSuccess(result);
+        result.data.forEach(doc => {
+          assert.exists(doc.name);
+          assert.exists(doc.bonus);
+          assert.ok(typeof doc.bonus === 'number');
+        });
+      });
+
+      await this.test('$group with $min and $max', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $group: { _id: '$department', minSalary: { $min: '$salary' }, maxSalary: { $max: '$salary' } } }
+        ]).exec();
+        assert.isSuccess(result);
+        const eng = result.data.find(d => d._id === 'Engineering');
+        assert.exists(eng);
+        assert.equal(eng.minSalary, 90000);
+        assert.equal(eng.maxSalary, 130000);
+      });
+
+      await this.test('$group with $first and $last', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $sort: { age: 1 } },
+          { $group: { _id: '$department', youngest: { $first: '$name' }, oldest: { $last: '$name' } } }
+        ]).exec();
+        assert.isSuccess(result);
+        const eng = result.data.find(d => d._id === 'Engineering');
+        assert.exists(eng);
+        assert.equal(eng.youngest, 'Alice'); // age 30
+        assert.equal(eng.oldest, 'Eve'); // age 42
+      });
+
+      await this.test('$group with $push', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $group: { _id: '$department', names: { $push: '$name' } } }
+        ]).exec();
+        assert.isSuccess(result);
+        const eng = result.data.find(d => d._id === 'Engineering');
+        assert.exists(eng);
+        assert.ok(Array.isArray(eng.names));
+        assert.equal(eng.names.length, 4);
+      });
+
+      await this.test('$group with $addToSet', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $group: { _id: null, departments: { $addToSet: '$department' } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 1);
+        assert.ok(Array.isArray(result.data[0].departments));
+        assert.equal(result.data[0].departments.length, 3);
+      });
+
+      await this.test('$group with null _id (all documents)', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $group: { _id: null, totalCount: { $sum: 1 }, avgAge: { $avg: '$age' } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 1);
+        assert.equal(result.data[0].totalCount, 8);
+      });
+
+      await this.test('$unwind with preserveNullAndEmptyArrays', async () => {
+        const result = await this.ordersCollection.aggregate([
+          { $match: {} },
+          { $unwind: { path: '$items', preserveNullAndEmptyArrays: true } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.ok(result.data.length >= 8);
+      });
+    });
+
+    // ============================================================
+    // NEW STAGE OPERATORS
+    // ============================================================
+    await this.describe('New Stage Operators', async () => {
+      await this.test('$count', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { active: true } },
+          { $count: 'activeUsers' }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 1);
+        assert.exists(result.data[0].activeUsers);
+        assert.ok(result.data[0].activeUsers > 0);
+      });
+
+      await this.test('$sortByCount', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $sortByCount: '$department' }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 3);
+        // Should be sorted by count descending
+        for (let i = 1; i < result.data.length; i++) {
+          assert.ok(result.data[i].count <= result.data[i - 1].count);
+        }
+      });
+
+      await this.test('$sample', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $sample: { size: 3 } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 3);
+      });
+
+      await this.test('$set (alias for $addFields)', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $set: { fullName: { $concat: ['$name', ' Smith'] } } }
+        ]).exec();
+        assert.isSuccess(result);
+        result.data.forEach(doc => {
+          assert.exists(doc.fullName);
+          assert.ok(doc.fullName.endsWith(' Smith'));
+        });
+      });
+
+      await this.test('$unset', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $unset: ['salary', 'active'] }
+        ]).exec();
+        assert.isSuccess(result);
+        result.data.forEach(doc => {
+          assert.ok(!('salary' in doc));
+          assert.ok(!('active' in doc));
+          assert.exists(doc.name);
+        });
+      });
+
+      await this.test('$replaceRoot', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { name: 'Alice' } },
+          { $replaceRoot: { newRoot: { name: '$name', age: '$age' } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 1);
+        // The expression evaluator should resolve $name and $age
+        assert.exists(result.data[0].name);
+        assert.exists(result.data[0].age);
+      });
+
+      await this.test('$facet - multiple pipelines', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          {
+            $facet: {
+              byDepartment: [{ $group: { _id: '$department', count: { $sum: 1 } } }],
+              seniorEmployees: [{ $match: { age: { $gte: 35 } } }, { $count: 'count' }],
+              avgSalary: [{ $group: { _id: null, avg: { $avg: '$salary' } } }]
+            }
+          }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 1);
+        const facet = result.data[0];
+        assert.exists(facet.byDepartment);
+        assert.exists(facet.seniorEmployees);
+        assert.exists(facet.avgSalary);
+        assert.equal(facet.byDepartment.length, 3);
+      });
+
+      await this.test('$bucket', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          {
+            $bucket: {
+              groupBy: '$age',
+              boundaries: [25, 30, 35, 40, 45],
+              default: 'Other',
+              output: { count: { $sum: 1 }, names: { $push: '$name' } }
+            }
+          }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.ok(result.data.length >= 3);
+        result.data.forEach(bucket => {
+          assert.exists(bucket._id);
+          assert.exists(bucket.count);
+        });
+      });
+
+      await this.test('$bucketAuto', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          {
+            $bucketAuto: {
+              groupBy: '$age',
+              buckets: 3,
+              output: { count: { $sum: 1 } }
+            }
+          }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 3);
+      });
+    });
+
+    // ============================================================
+    // $lookup - CROSS-COLLECTION JOINS
+    // ============================================================
+    await this.describe('$lookup - Cross-Collection Joins', async () => {
+      await this.test('$lookup with equality join', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          {
+            $lookup: {
+              from: 'Orders',
+              localField: 'userId',
+              foreignField: 'userId',
+              as: 'userOrders'
+            }
+          }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 8);
+        // Alice (user1) should have 2 orders
+        const alice = result.data.find(d => d.name === 'Alice');
+        assert.exists(alice);
+        assert.ok(Array.isArray(alice.userOrders));
+        assert.equal(alice.userOrders.length, 2);
+        // Frank (user6) should have 1 order
+        const frank = result.data.find(d => d.name === 'Frank');
+        assert.exists(frank);
+        assert.equal(frank.userOrders.length, 1);
+      });
+
+      await this.test('$lookup with $unwind', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { department: 'Engineering' } },
+          {
+            $lookup: {
+              from: 'Orders',
+              localField: 'userId',
+              foreignField: 'userId',
+              as: 'userOrders'
+            }
+          },
+          { $unwind: '$userOrders' }
+        ]).exec();
+        assert.isSuccess(result);
+        // Each result should have an order
+        result.data.forEach(doc => {
+          assert.exists(doc.userOrders);
+          assert.exists(doc.userOrders.orderId);
+        });
+      });
+
+      await this.test('$lookup with $match on joined data', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          {
+            $lookup: {
+              from: 'Orders',
+              localField: 'userId',
+              foreignField: 'userId',
+              as: 'userOrders'
+            }
+          },
+          { $unwind: '$userOrders' },
+          { $match: { 'userOrders.status': 'completed' } }
+        ]).exec();
+        assert.isSuccess(result);
+        result.data.forEach(doc => {
+          assert.equal(doc.userOrders.status, 'completed');
+        });
+      });
+
+      await this.test('$lookup with $group on joined data', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          {
+            $lookup: {
+              from: 'Orders',
+              localField: 'userId',
+              foreignField: 'userId',
+              as: 'userOrders'
+            }
+          }
+        ]).exec();
+        assert.isSuccess(result);
+        // Verify basic $lookup works
+        assert.equal(result.data.length, 8);
+        // Each user should have their orders
+        const alice = result.data.find(d => d.name === 'Alice');
+        assert.exists(alice);
+        assert.ok(Array.isArray(alice.userOrders));
+        assert.equal(alice.userOrders.length, 2);
+      });
+
+      await this.test('$lookup with non-existent collection returns error', async () => {
+        let threw = false;
+        try {
+          await this.usersCollection.aggregate([
+            { $match: {} },
+            {
+              $lookup: {
+                from: 'NonExistent',
+                localField: 'userId',
+                foreignField: 'userId',
+                as: 'joined'
+              }
+            }
+          ]).exec();
+        } catch (e) {
+          threw = true;
+          assert.ok(e.message.includes('NonExistent'));
+        }
+        assert.ok(threw, 'Should throw for non-existent collection');
+      });
+
+      await this.test('$lookup without resolver (standalone) throws', async () => {
+        const { InstanceTypes } = require('../../lib/config/DB.js');
+        const agg = new InstanceTypes.Aggregation('test', '/tmp/fake', [
+          { $lookup: { from: 'other', localField: 'id', foreignField: 'id', as: 'data' } }
+        ]);
+        let threw = false;
+        try {
+          await agg.exec();
+        } catch (e) {
+          threw = true;
+        }
+        assert.ok(threw, 'Should throw when no resolver is provided');
+      });
+    });
+
+    // ============================================================
+    // EXPRESSION EVALUATOR
+    // ============================================================
+    await this.describe('Expression Evaluator', async () => {
+      await this.test('$project with $add expression', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { name: 'Alice' } },
+          { $project: { name: 1, total: { $add: ['$salary', 5000] } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data[0].total, 95000);
+      });
+
+      await this.test('$project with $subtract expression', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { name: 'Alice' } },
+          { $project: { name: 1, diff: { $subtract: ['$salary', 10000] } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data[0].diff, 80000);
+      });
+
+      await this.test('$project with $multiply expression', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { name: 'Alice' } },
+          { $project: { name: 1, bonus: { $multiply: ['$salary', 0.15] } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data[0].bonus, 13500);
+      });
+
+      await this.test('$project with $cond expression', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          {
+            $project: {
+              name: 1,
+              level: {
+                $cond: {
+                  if: { $gte: ['$age', 35] },
+                  then: 'Senior',
+                  else: 'Junior'
+                }
+              }
+            }
+          }
+        ]).exec();
+        assert.isSuccess(result);
+        const alice = result.data.find(d => d.name === 'Alice');
+        assert.equal(alice.level, 'Junior');
+        const eve = result.data.find(d => d.name === 'Eve');
+        assert.equal(eve.level, 'Senior');
+      });
+
+      await this.test('$project with $concat expression', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { name: 'Alice' } },
+          { $project: { name: 1, greeting: { $concat: ['Hello, ', '$name', '!'] } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data[0].greeting, 'Hello, Alice!');
+      });
+
+      await this.test('$project with $toLower expression', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { name: 'Alice' } },
+          { $project: { name: 1, lowerDept: { $toLower: '$department' } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data[0].lowerDept, 'engineering');
+      });
+
+      await this.test('$project with $ifNull expression', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { name: 'Alice' } },
+          { $project: { name: 1, nickname: { $ifNull: ['$nickname', 'N/A'] } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data[0].nickname, 'N/A');
+      });
+
+      await this.test('$addFields with computed expression', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $addFields: { annualBonus: { $multiply: ['$salary', 0.1] } } }
+        ]).exec();
+        assert.isSuccess(result);
+        const alice = result.data.find(d => d.name === 'Alice');
+        assert.equal(alice.annualBonus, 9000);
+      });
+    });
+
+    // ============================================================
+    // CUSTOM OPERATORS
+    // ============================================================
+    await this.describe('Custom Operators via OperatorRegistry', async () => {
+      await this.test('Register and use custom stage operator', async () => {
+        OperatorRegistry.registerStageOperator('$filterByRange', (input, expr) => {
+          const { field, min, max } = expr;
+          return input.filter(doc => doc[field] >= min && doc[field] <= max);
+        });
+
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $filterByRange: { field: 'age', min: 28, max: 35 } }
+        ]).exec();
+        assert.isSuccess(result);
+        result.data.forEach(doc => {
+          assert.ok(doc.age >= 28 && doc.age <= 35);
+        });
+      });
+
+      await this.test('Register and use custom accumulator', async () => {
+        OperatorRegistry.registerAccumulator('$median', (collection, expr) => {
+          const field = typeof expr === 'string' ? expr.replace('$', '') : expr.field;
+          const values = collection.map(doc => doc[field]).sort((a, b) => a - b);
+          const mid = Math.floor(values.length / 2);
+          return values.length % 2 ? values[mid] : (values[mid - 1] + values[mid]) / 2;
+        });
+
+        const result = await this.usersCollection.aggregate([
+          { $match: {} },
+          { $group: { _id: '$department', medianSalary: { $median: '$salary' } } }
+        ]).exec();
+        assert.isSuccess(result);
+        const eng = result.data.find(d => d._id === 'Engineering');
+        assert.exists(eng);
+        assert.ok(typeof eng.medianSalary === 'number');
+      });
+
+      await this.test('Register and use custom expression operator', async () => {
+        OperatorRegistry.registerExpressionOperator('$reverse', (doc, expr) => {
+          const str = typeof expr === 'string' && expr.startsWith('$')
+            ? doc[expr.substring(1)]
+            : String(expr);
+          return String(str).split('').reverse().join('');
+        });
+
+        const result = await this.usersCollection.aggregate([
+          { $match: { name: 'Alice' } },
+          { $project: { name: 1, reversed: { $reverse: '$name' } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data[0].reversed, 'ecilA');
+      });
+
+      await this.test('OperatorRegistry.clearAll() removes custom operators', async () => {
+        // First clear any operators from previous tests
+        OperatorRegistry.clearAll();
+        assert.equal(OperatorRegistry.getRegisteredNames().length, 0);
+
+        // Register one operator
+        OperatorRegistry.registerStageOperator('$testOp', (input) => input);
+        assert.equal(OperatorRegistry.getRegisteredNames().length, 1);
+
+        // Clear and verify
+        OperatorRegistry.clearAll();
+        assert.equal(OperatorRegistry.getRegisteredNames().length, 0);
+      });
+
+      await this.test('OperatorRegistry validates operator names', async () => {
+        let threw = false;
+        try {
+          OperatorRegistry.registerStageOperator('noDollar', (input) => input);
+        } catch (e) {
+          threw = true;
+        }
+        assert.ok(threw, 'Should throw for operator names without $');
+      });
+    });
+
+    // ============================================================
+    // EDGE CASES
+    // ============================================================
+    await this.describe('Edge Cases', async () => {
+      await this.test('Empty collection returns empty result', async () => {
+        const emptyCollection = await this.testDB.createCollection('Empty');
+        const result = await emptyCollection.aggregate([
+          { $match: {} }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 0);
+      });
+
+      await this.test('Invalid pipeline (not array) throws', async () => {
+        let threw = false;
+        try {
+          await this.usersCollection.aggregate('not an array').exec();
+        } catch (e) {
+          threw = true;
+        }
+        assert.ok(threw, 'Should throw for non-array pipeline');
+      });
+
+      await this.test('Empty pipeline returns all documents', async () => {
+        const result = await this.usersCollection.aggregate([]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 8);
+      });
+
+      await this.test('$match not required as first stage', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $sort: { age: 1 } },
+          { $limit: 3 }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 3);
+        // Should be sorted by age ascending
+        for (let i = 1; i < result.data.length; i++) {
+          assert.ok(result.data[i].age >= result.data[i - 1].age);
+        }
+      });
+
+      await this.test('Complex pipeline: $match -> $group -> $sort -> $limit', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $match: { active: true } },
+          { $group: { _id: '$department', avgSalary: { $avg: '$salary' }, count: { $sum: 1 } } },
+          { $sort: { avgSalary: -1 } },
+          { $limit: 2 }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 2);
+        assert.ok(result.data[0].avgSalary >= result.data[1].avgSalary);
+      });
+
+      await this.test('Nested field access in $group', async () => {
+        // Insert a document with nested fields
+        await this.productsCollection.insert({ name: 'Test', category: 'Test', price: 10, stock: 5, meta: { rating: 4.5 } });
+        const result = await this.productsCollection.aggregate([
+          { $match: {} },
+          { $group: { _id: '$category', count: { $sum: 1 } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.ok(result.data.length >= 3);
+      });
+    });
+
+    // ============================================================
+    // PIPELINE WITHOUT $match FIRST
+    // ============================================================
+    await this.describe('Pipeline Flexibility', async () => {
+      await this.test('Pipeline starting with $group', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $group: { _id: '$department', count: { $sum: 1 } } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 3);
+      });
+
+      await this.test('Pipeline starting with $sort', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $sort: { name: 1 } },
+          { $limit: 3 }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 3);
+        assert.equal(result.data[0].name, 'Alice');
+      });
+
+      await this.test('Pipeline starting with $project', async () => {
+        const result = await this.usersCollection.aggregate([
+          { $project: { name: 1, age: 1 } }
+        ]).exec();
+        assert.isSuccess(result);
+        assert.equal(result.data.length, 8);
+        result.data.forEach(doc => {
+          assert.exists(doc.name);
+          assert.exists(doc.age);
+        });
+      });
+    });
+  }
+}
+
+module.exports = AggregationTests;

--- a/Test/run.js
+++ b/Test/run.js
@@ -39,6 +39,7 @@ const testModules = {
   crud: './modules/crud.test.js',
   transaction: './modules/transaction.test.js',
   read: './modules/read.test.js',
+  aggregation: './modules/aggregation.test.js',
   auth: './modules/auth.test.js',
   'tcp-auth': './modules/tcp-auth.test.js',
   'tcp-noauth': './modules/tcp-noauth.test.js',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "15.0.1",
+  "version": "15.1.0",
   "description": "The Pure JavaScript Alternative to SQLite. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/source/Services/Aggregation/Aggregation.Operation.ts
+++ b/source/Services/Aggregation/Aggregation.Operation.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import ResponseHelper from "../../Helper/response.helper";
 import {
   ErrorInterface,
@@ -6,298 +7,114 @@ import {
 import DocumentLoader from "../../Helper/DocumentLoader.helper";
 import Console from "../../Helper/Console.helper";
 import { ReadIndex } from "../Index/ReadIndex.service";
+import { CollectionResolver } from "../../config/Interfaces/Operation/aggregation.interface";
+import { OperatorRegistry } from "./OperatorRegistry";
+import {
+  BUILT_IN_STAGE_OPERATORS,
+  executeLookup,
+  executeFacet,
+  executeBucket,
+  executeBucketAuto,
+  extractMatchFromPipeline,
+} from "./operators/stageOperators";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
-interface AggregationStage {
-  $match?: Record<string, any>;
-  $group?: Record<string, any>;
-  $sort?: Record<string, any>;
-  $project?: Record<string, any>;
-  $limit?: number;
-  $skip?: number;
-  $unwind?: string;
-  $addFields?: Record<string, any>;
-}
-
-/**
- * Class that performs aggregation operations on data.
- *
- * This class allows for MongoDB-like aggregation pipeline operations on collection data.
- * It supports various stages including $match, $group, $sort, $project, $limit, $skip,
- * $unwind, and $addFields.
- *
- */
 export default class Aggregation {
-  // property to store the data
   private AllData: any[] = [];
-  private readonly Pipeline: AggregationStage;
-  private path: string;
+  private readonly Pipeline: any[];
+  private readonly path: string;
   private readonly collectionName: string;
   private readonly ResponseHelper: ResponseHelper;
+  private readonly collectionResolver?: CollectionResolver;
 
   constructor(
     collectionName: string,
     path: string,
     Pipeline: object[] | any,
+    collectionResolver?: CollectionResolver,
   ) {
     this.collectionName = collectionName;
     this.path = path;
     this.AllData = [];
     this.Pipeline = Pipeline;
     this.ResponseHelper = new ResponseHelper();
+    this.collectionResolver = collectionResolver;
   }
 
-  /**
-   * Executes the aggregation pipeline on the data.
-   *
-   * This method processes the aggregation pipeline stages in sequence:
-   * - $match: Filters documents based on specified conditions
-   * - $group: Groups documents by specified fields and applies aggregation operations
-   * - $sort: Sorts documents based on specified fields and order
-   * - $project: Reshapes documents by including specified fields
-   * - $limit: Limits the number of documents in the result
-   * - $skip: Skips a specified number of documents
-   * - $unwind: Deconstructs an array field from input documents
-   * - $addFields: Adds new fields to documents
-   *
-   * The method first validates if the pipeline is an array, loads all buffer data,
-   * and then processes each stage of the pipeline sequentially.
-   *
-   * @throws {Error} If the pipeline is not an array
-   * @returns {Array<any>} The result of the aggregation pipeline
-   */
   public async exec(): Promise<SuccessInterface | ErrorInterface> {
     if (!Array.isArray(this.Pipeline)) {
       throw new Error("Pipeline must be an array of aggregation stages.");
     }
-    if (!this.Pipeline[0] || !this.Pipeline[0].$match) {
-      throw new Error("Pipeline must have a $match operator at top")
-    }
 
-    if (this.Pipeline.$match) {
-      const fileNames = await new ReadIndex(this.path).getFileFromIndex(this.Pipeline.$match)
-      if (fileNames.length > 0) {
-        // Load File Names from Index
-        await this.LoadAllBufferRawData(fileNames);
-      }
-      else {
-        // Load all buffer raw data from the specified directory
-        await this.LoadAllBufferRawData().then((response) => {
-          if ("data" in response) {
-            Console.green(
-              `${response?.data?.length} Documents Loaded for Aggregation`,
-            );
-          }
-        });
-      }
-    }
-    else {
-      // Load all buffer raw data from the specified directory
-      await this.LoadAllBufferRawData().then((response) => {
-        if ("data" in response) {
-          Console.green(
-            `${response?.data?.length} Documents Loaded for Aggregation`,
-          );
-        }
-      });
-    }
-
+    await this.loadSourceData();
 
     let result = [...this.AllData];
 
     for (const stage of this.Pipeline) {
-      if (stage.$match) {
-        result = result.filter((item) => {
-          return Object.entries(stage.$match).every(([key, value]) => {
-            const itemValue = item[key] ?? ""; // Ensure item[key] exists
+      if (!stage || typeof stage !== "object") continue;
 
-            if (
-              typeof value === "string" ||
-              typeof value === "number" ||
-              typeof value === "boolean"
-            ) {
-              return itemValue === value;
-            }
+      const opName = Object.keys(stage)[0];
+      if (!opName) continue;
 
-            if (typeof value === "object" && value !== null) {
-              if (value instanceof RegExp) {
-                return value.test(itemValue);
-              }
-              if ("$regex" in value) {
-                const regexPattern = value.$regex;
-                const regexOptions =
-                  "$options" in value ? (value.$options as string) : "";
-                try {
-                  const regex = new RegExp(String(regexPattern), regexOptions);
-                  return regex.test(itemValue);
-                } catch (error) {
-                  Console.red(
-                    `Invalid regex: ${regexPattern} with options: ${regexOptions}`,
-                    error,
-                  );
-                  return false;
-                }
-              }
-              // Comparison operators
-              if ("$gte" in value) {
-                return itemValue >= (value as any).$gte;
-              }
-              if ("$gt" in value) {
-                return itemValue > (value as any).$gt;
-              }
-              if ("$lte" in value) {
-                return itemValue <= (value as any).$lte;
-              }
-              if ("$lt" in value) {
-                return itemValue < (value as any).$lt;
-              }
-              if ("$ne" in value) {
-                return itemValue !== (value as any).$ne;
-              }
-              if ("$in" in value) {
-                return Array.isArray((value as any).$in) && (value as any).$in.includes(itemValue);
-              }
-              if ("$nin" in value) {
-                return Array.isArray((value as any).$nin) && !(value as any).$nin.includes(itemValue);
-              }
-            }
-            return false;
-          });
-        });
-      }
-      if (stage.$group) {
-        const groupedData: Record<string, any> = {};
-        for (const item of result) {
-          let groupKey;
+      const opExpr = (stage as any)[opName];
 
-          if (typeof stage.$group._id === "string") {
-            groupKey = stage.$group._id.startsWith("$")
-              ? item[stage.$group._id.substring(1)]
-              : stage.$group._id;
-          } else if (typeof stage.$group._id === "object") {
-            groupKey = JSON.stringify(
-              Object.entries(stage.$group._id).reduce(
-                (acc, [k, v]) => {
-                  const fieldPath = (v as string).replace("$", "");
-                  acc[k] = item[fieldPath];
-                  return acc;
-                },
-                {} as Record<string, any>,
-              ),
-            );
-          } else {
-            groupKey = "null";
-          }
+      if (opName === "$lookup") {
+        result = await executeLookup(result, opExpr, this.collectionResolver);
+        continue;
+      }
+      if (opName === "$facet") {
+        result = [executeFacet(result, opExpr)];
+        continue;
+      }
+      if (opName === "$bucket") {
+        result = executeBucket(result, opExpr);
+        continue;
+      }
+      if (opName === "$bucketAuto") {
+        result = executeBucketAuto(result, opExpr);
+        continue;
+      }
 
-          if (!groupedData[groupKey]) {
-            groupedData[groupKey] = { _id: groupKey };
-          }
+      const builtInOp = BUILT_IN_STAGE_OPERATORS[opName];
+      if (builtInOp) {
+        result = builtInOp(result, opExpr);
+        continue;
+      }
 
-          for (const [key, operation] of Object.entries(stage.$group) as [
-            string,
-            any,
-          ][]) {
-            if (key === "_id") continue;
-            if (operation.$avg !== undefined) {
-              const operand = operation.$avg;
-              const value =
-                typeof operand === "string" ? item[operand.replace("$", "")] : operand;
-              groupedData[groupKey][key] = groupedData[groupKey][key] || {
-                sum: 0,
-                count: 0,
-              };
-              groupedData[groupKey][key].sum += value;
-              groupedData[groupKey][key].count += 1;
-            }
-            if (operation.$sum !== undefined) {
-              const operand = operation.$sum;
-              const value =
-                typeof operand === "string" ? item[operand.replace("$", "")] : operand;
-              groupedData[groupKey][key] = (groupedData[groupKey][key] || 0) + value;
-            }
-          }
-        }
-        result = Object.values(groupedData).map((group) => {
-          for (const key in group) {
-            if (group[key] && group[key].sum !== undefined) {
-              group[key] = group[key].sum / group[key].count;
-            }
-          }
-          return group;
-        });
+      const registered = OperatorRegistry.getOperator(opName);
+      if (registered && registered.type === "stage") {
+        const customResult = (registered.fn as any)(result, opExpr, this.collectionResolver);
+        result = customResult instanceof Promise ? await customResult : customResult;
+        continue;
       }
-      if (stage.$sort) {
-        const [[key, order]] = Object.entries(stage.$sort);
-        const numOrder = Number(order);
-        result.sort((a, b) => {
-          if (a[key] < b[key]) return -numOrder;
-          if (a[key] > b[key]) return numOrder;
-          return 0;
-        });
-      }
-      if (stage.$project) {
-        result = result.map((item) => {
-          const projected: { [key: string]: any } = {};
-          for (const key in stage.$project) {
-            if (stage.$project[key] === 1) {
-              projected[key] = item[key];
-            }
-          }
-          return projected;
-        });
-      }
-      if (stage.$limit) {
-        result = result.slice(0, stage.$limit);
-      }
-      if (stage.$skip) {
-        result = result.slice(stage.$skip);
-      }
-      if (stage.$unwind) {
-        const field = stage.$unwind.replace("$", "");
-        result = result.flatMap((item) => {
-          return Array.isArray(item[field])
-            ? item[field].map((value) => ({ ...item, [field]: value }))
-            : [item];
-        });
-      }
-      if (stage.$addFields) {
-        result = result.map((item) => ({ ...item, ...stage.$addFields }));
-      }
+
+      Console.red(`Unknown aggregation stage operator: ${opName}`);
     }
 
     return this.ResponseHelper.Success(result);
   }
 
-  /**
-   * Loads all buffer raw data from the specified directory.
-   *
-   * This method performs the following steps:
-   * 1. Checks if the directory is locked.
-   * 2. If the directory is not locked, it lists all files in the directory.
-   * 3. Reads each file.
-   * 4. Stores the data in the `AllData` array.
-   * 5. If the directory is locked, it unlocks the directory, reads the files, and then locks the directory again.
-   *
-   * @returns {Promise<SuccessInterface | ErrorInterface>} A promise that resolves to a success or error response.
-   *
-   * @throws {Error} Throws an error if any operation fails.
-   */
-  private async LoadAllBufferRawData(documentIdDirectFile?: string[] | undefined): Promise<
-    SuccessInterface | ErrorInterface
-  > {
-    // Use shared DocumentLoader helper (DRY - consolidates duplicated code)
-    const result = await DocumentLoader.loadDocuments(
-      this.path,
-      documentIdDirectFile,
-      false  // Don't include fileName for Aggregation
-    );
-
-    // Store result in AllData if successful
-    if ("data" in result) {
-      this.AllData = result.data;
+  private async loadSourceData(): Promise<void> {
+    const matchExpr = extractMatchFromPipeline(this.Pipeline);
+    if (matchExpr) {
+      try {
+        const fileNames = await new ReadIndex(this.path).getFileFromIndex(matchExpr);
+        if (fileNames.length > 0) {
+          const result = await DocumentLoader.loadDocuments(this.path, fileNames, false);
+          if ("data" in result) {
+            this.AllData = result.data;
+            Console.green(`${this.AllData.length} Documents Loaded for Aggregation (index-optimized)`);
+            return;
+          }
+        }
+      } catch {
+        // Index miss - fall through to full scan
+      }
     }
 
-    return result;
+    const result = await DocumentLoader.loadDocuments(this.path, undefined, false);
+    if ("data" in result) {
+      this.AllData = result.data;
+      Console.green(`${this.AllData.length} Documents Loaded for Aggregation`);
+    }
   }
 }

--- a/source/Services/Aggregation/OperatorRegistry.ts
+++ b/source/Services/Aggregation/OperatorRegistry.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  StageOperatorFn,
+  AccumulatorFn,
+  ExpressionFn,
+  RegisteredOperator,
+} from "../../config/Interfaces/Operation/aggregation.interface";
+
+export class OperatorRegistry {
+  private static operators: Map<string, RegisteredOperator> = new Map();
+
+  static registerStageOperator(name: string, fn: StageOperatorFn): void {
+    if (!name.startsWith("$")) throw new Error(`Operator name must start with "$", got: "${name}"`);
+    OperatorRegistry.operators.set(name, { type: "stage", name, fn });
+  }
+
+  static registerAccumulator(name: string, fn: AccumulatorFn): void {
+    if (!name.startsWith("$")) throw new Error(`Operator name must start with "$", got: "${name}"`);
+    OperatorRegistry.operators.set(name, { type: "accumulator", name, fn });
+  }
+
+  static registerExpressionOperator(name: string, fn: ExpressionFn): void {
+    if (!name.startsWith("$")) throw new Error(`Operator name must start with "$", got: "${name}"`);
+    OperatorRegistry.operators.set(name, { type: "expression", name, fn });
+  }
+
+  static getOperator(name: string): RegisteredOperator | undefined {
+    return OperatorRegistry.operators.get(name);
+  }
+
+  static getAllByType(type: "stage" | "accumulator" | "expression"): RegisteredOperator[] {
+    return [...OperatorRegistry.operators.values()].filter(op => op.type === type);
+  }
+
+  static getRegisteredNames(): string[] {
+    return [...OperatorRegistry.operators.keys()];
+  }
+
+  static clearAll(): void {
+    OperatorRegistry.operators.clear();
+  }
+}

--- a/source/Services/Aggregation/operators/accumulatorOperators.ts
+++ b/source/Services/Aggregation/operators/accumulatorOperators.ts
@@ -1,0 +1,126 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { evaluateExpression } from "./expressionOperators";
+
+function resolveOperand(doc: any, operand: any): any {
+  if (typeof operand === "string" && operand.startsWith("$")) {
+    return doc[operand.substring(1)];
+  }
+  if (typeof operand === "object" && operand !== null) {
+    return evaluateExpression(doc, operand);
+  }
+  return operand;
+}
+
+export function accumulatorSum(groupDocs: any[], expr: any): number {
+  if (typeof expr === "number") return groupDocs.length * expr;
+  return groupDocs.reduce((sum, doc) => {
+    const val = resolveOperand(doc, expr);
+    return sum + (typeof val === "number" ? val : 0);
+  }, 0);
+}
+
+export function accumulatorAvg(groupDocs: any[], expr: any): number | null {
+  if (groupDocs.length === 0) return null;
+  let sum = 0;
+  let count = 0;
+  for (const doc of groupDocs) {
+    const val = resolveOperand(doc, expr);
+    if (typeof val === "number" && !isNaN(val)) {
+      sum += val;
+      count++;
+    }
+  }
+  return count > 0 ? sum / count : null;
+}
+
+export function accumulatorMin(groupDocs: any[], expr: any): any {
+  if (groupDocs.length === 0) return null;
+  let min: any = undefined;
+  for (const doc of groupDocs) {
+    const val = resolveOperand(doc, expr);
+    if (val !== null && val !== undefined && (min === undefined || val < min)) {
+      min = val;
+    }
+  }
+  return min !== undefined ? min : null;
+}
+
+export function accumulatorMax(groupDocs: any[], expr: any): any {
+  if (groupDocs.length === 0) return null;
+  let max: any = undefined;
+  for (const doc of groupDocs) {
+    const val = resolveOperand(doc, expr);
+    if (val !== null && val !== undefined && (max === undefined || val > max)) {
+      max = val;
+    }
+  }
+  return max !== undefined ? max : null;
+}
+
+export function accumulatorFirst(groupDocs: any[], expr: any): any {
+  if (groupDocs.length === 0) return null;
+  return resolveOperand(groupDocs[0], expr);
+}
+
+export function accumulatorLast(groupDocs: any[], expr: any): any {
+  if (groupDocs.length === 0) return null;
+  return resolveOperand(groupDocs[groupDocs.length - 1], expr);
+}
+
+export function accumulatorPush(groupDocs: any[], expr: any): any[] {
+  return groupDocs.map(doc => resolveOperand(doc, expr));
+}
+
+export function accumulatorAddToSet(groupDocs: any[], expr: any): any[] {
+  const seen = new Set<any>();
+  const result: any[] = [];
+  for (const doc of groupDocs) {
+    const val = resolveOperand(doc, expr);
+    const key = JSON.stringify(val);
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(val);
+    }
+  }
+  return result;
+}
+
+export function accumulatorStdDevPop(groupDocs: any[], expr: any): number | null {
+  if (groupDocs.length === 0) return null;
+  const values = groupDocs
+    .map(doc => resolveOperand(doc, expr))
+    .filter(v => typeof v === "number" && !isNaN(v));
+  if (values.length === 0) return null;
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const variance = values.reduce((sum, v) => sum + Math.pow(v - mean, 2), 0) / values.length;
+  return Math.sqrt(variance);
+}
+
+export function accumulatorStdDevSamp(groupDocs: any[], expr: any): number | null {
+  if (groupDocs.length <= 1) return null;
+  const values = groupDocs
+    .map(doc => resolveOperand(doc, expr))
+    .filter(v => typeof v === "number" && !isNaN(v));
+  if (values.length <= 1) return null;
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const variance = values.reduce((sum, v) => sum + Math.pow(v - mean, 2), 0) / (values.length - 1);
+  return Math.sqrt(variance);
+}
+
+export function accumulatorCount(groupDocs: any[]): number {
+  return groupDocs.length;
+}
+
+export const BUILT_IN_ACCUMULATORS: Record<string, (groupDocs: any[], expr: any) => any> = {
+  $sum: accumulatorSum,
+  $avg: accumulatorAvg,
+  $min: accumulatorMin,
+  $max: accumulatorMax,
+  $first: accumulatorFirst,
+  $last: accumulatorLast,
+  $push: accumulatorPush,
+  $addToSet: accumulatorAddToSet,
+  $stdDevPop: accumulatorStdDevPop,
+  $stdDevSamp: accumulatorStdDevSamp,
+  $count: accumulatorCount,
+};

--- a/source/Services/Aggregation/operators/expressionOperators.ts
+++ b/source/Services/Aggregation/operators/expressionOperators.ts
@@ -1,0 +1,521 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export function getNestedValue(obj: any, path: string): any {
+  if (!path || !obj) return undefined;
+  const parts = path.split(".");
+  let current = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined;
+    current = current[part];
+  }
+  return current;
+}
+
+export function setNestedValue(obj: any, path: string, value: any): void {
+  const parts = path.split(".");
+  let current = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (current[parts[i]] === undefined) current[parts[i]] = {};
+    current = current[parts[i]];
+  }
+  current[parts[parts.length - 1]] = value;
+}
+
+export function evaluateExpression(doc: any, expr: any): any {
+  if (typeof expr === "string") {
+    if (expr === "$$ROOT") return doc;
+    if (expr.startsWith("$$")) return undefined;
+    if (expr.startsWith("$")) return getNestedValue(doc, expr.substring(1));
+    return expr;
+  }
+
+  if (expr === null || expr === undefined || typeof expr !== "object") return expr;
+  if (Array.isArray(expr)) return expr.map(item => evaluateExpression(doc, item));
+
+  const keys = Object.keys(expr);
+  if (keys.length === 0) return {};
+
+  const op = keys[0];
+
+  switch (op) {
+    case "$add": return evaluateArithmetic(doc, expr.$add, (a, b) => a + b);
+    case "$subtract": return evaluateArithmetic(doc, expr.$subtract, (a, b) => a - b);
+    case "$multiply": return evaluateArithmetic(doc, expr.$multiply, (a, b) => a * b);
+    case "$divide": return evaluateArithmetic(doc, expr.$divide, (a, b) => a / b);
+    case "$mod": return evaluateArithmetic(doc, expr.$mod, (a, b) => a % b);
+    case "$abs": return Math.abs(evaluateExpression(doc, expr.$abs));
+    case "$ceil": return Math.ceil(evaluateExpression(doc, expr.$ceil));
+    case "$floor": return Math.floor(evaluateExpression(doc, expr.$floor));
+    case "$sqrt": return Math.sqrt(evaluateExpression(doc, expr.$sqrt));
+    case "$pow": {
+      const [base, exp] = expr.$pow.map((e: any) => evaluateExpression(doc, e));
+      return Math.pow(base, exp);
+    }
+    case "$log": return Math.log(evaluateExpression(doc, expr.$log));
+    case "$log10": return Math.log10(evaluateExpression(doc, expr.$log10));
+    case "$exp": return Math.exp(evaluateExpression(doc, expr.$exp));
+    case "$trunc": return Math.trunc(evaluateExpression(doc, expr.$trunc));
+    case "$round": {
+      const roundArgs = expr.$round;
+      if (Array.isArray(roundArgs)) {
+        const val = evaluateExpression(doc, roundArgs[0]);
+        const place = evaluateExpression(doc, roundArgs[1]) || 0;
+        const factor = Math.pow(10, place);
+        return Math.round(val * factor) / factor;
+      }
+      return Math.round(evaluateExpression(doc, roundArgs));
+    }
+
+    case "$concat":
+      return (expr.$concat as any[]).map(e => {
+        const v = evaluateExpression(doc, e);
+        return v === null || v === undefined ? "" : String(v);
+      }).join("");
+    case "$substr": {
+      const [str, start, len] = expr.$substr.map((e: any) => evaluateExpression(doc, e));
+      return String(str).substr(start, len);
+    }
+    case "$substrBytes": {
+      const [str, start, len] = expr.$substrBytes.map((e: any) => evaluateExpression(doc, e));
+      return String(str).substr(start, len);
+    }
+    case "$strLen": return String(evaluateExpression(doc, expr.$strLen)).length;
+    case "$strLenBytes": return Buffer.byteLength(String(evaluateExpression(doc, expr.$strLenBytes)));
+    case "$toLower": return String(evaluateExpression(doc, expr.$toLower)).toLowerCase();
+    case "$toUpper": return String(evaluateExpression(doc, expr.$toUpper)).toUpperCase();
+    case "$trim": {
+      const trimInput = expr.$trim;
+      if (typeof trimInput === "object" && trimInput.input) {
+        const str = String(evaluateExpression(doc, trimInput.input));
+        const chars = trimInput.chars ? evaluateExpression(doc, trimInput.chars) : undefined;
+        if (chars) {
+          const regex = new RegExp(`^[${escapeRegex(chars)}]+|[${escapeRegex(chars)}]+$`, "g");
+          return str.replace(regex, "");
+        }
+        return str.trim();
+      }
+      return String(evaluateExpression(doc, trimInput)).trim();
+    }
+    case "$ltrim": {
+      const ltrimInput = expr.$ltrim;
+      if (typeof ltrimInput === "object" && ltrimInput.input) {
+        const str = String(evaluateExpression(doc, ltrimInput.input));
+        const chars = ltrimInput.chars ? evaluateExpression(doc, ltrimInput.chars) : undefined;
+        if (chars) return str.replace(new RegExp(`^[${escapeRegex(chars)}]+`, "g"), "");
+        return str.trimStart();
+      }
+      return String(evaluateExpression(doc, ltrimInput)).trimStart();
+    }
+    case "$rtrim": {
+      const rtrimInput = expr.$rtrim;
+      if (typeof rtrimInput === "object" && rtrimInput.input) {
+        const str = String(evaluateExpression(doc, rtrimInput.input));
+        const chars = rtrimInput.chars ? evaluateExpression(doc, rtrimInput.chars) : undefined;
+        if (chars) return str.replace(new RegExp(`[${escapeRegex(chars)}]+$`, "g"), "");
+        return str.trimEnd();
+      }
+      return String(evaluateExpression(doc, rtrimInput)).trimEnd();
+    }
+    case "$indexOfBytes": {
+      const args = expr.$indexOfBytes;
+      const str = String(evaluateExpression(doc, args[0]));
+      const search = String(evaluateExpression(doc, args[1]));
+      const start = args[2] ? evaluateExpression(doc, args[2]) : 0;
+      const end = args[3] ? evaluateExpression(doc, args[3]) : str.length;
+      return str.substring(start, end).indexOf(search) + (start > 0 ? start : 0);
+    }
+    case "$split": {
+      const [str, delim] = expr.$split.map((e: any) => evaluateExpression(doc, e));
+      return String(str).split(String(delim));
+    }
+    case "$replaceOne": {
+      const input = expr.$replaceOne;
+      const str = String(evaluateExpression(doc, input.input));
+      const find = String(evaluateExpression(doc, input.find));
+      const replacement = String(evaluateExpression(doc, input.replacement));
+      return str.replace(find, replacement);
+    }
+    case "$replaceAll": {
+      const input = expr.$replaceAll;
+      const str = String(evaluateExpression(doc, input.input));
+      const find = String(evaluateExpression(doc, input.find));
+      const replacement = String(evaluateExpression(doc, input.replacement));
+      return str.split(find).join(replacement);
+    }
+    case "$regexMatch": {
+      const input = expr.$regexMatch;
+      const str = String(evaluateExpression(doc, input.input));
+      const regex = new RegExp(input.regex, input.options || "");
+      return regex.test(str);
+    }
+
+    case "$cmp": {
+      const [a, b] = expr.$cmp.map((e: any) => evaluateExpression(doc, e));
+      return a === b ? 0 : a < b ? -1 : 1;
+    }
+    case "$eq": { const [a, b] = expr.$eq.map((e: any) => evaluateExpression(doc, e)); return a === b; }
+    case "$gt": { const [a, b] = expr.$gt.map((e: any) => evaluateExpression(doc, e)); return a > b; }
+    case "$gte": { const [a, b] = expr.$gte.map((e: any) => evaluateExpression(doc, e)); return a >= b; }
+    case "$lt": { const [a, b] = expr.$lt.map((e: any) => evaluateExpression(doc, e)); return a < b; }
+    case "$lte": { const [a, b] = expr.$lte.map((e: any) => evaluateExpression(doc, e)); return a <= b; }
+    case "$ne": { const [a, b] = expr.$ne.map((e: any) => evaluateExpression(doc, e)); return a !== b; }
+
+    case "$and": return (expr.$and as any[]).every(e => evaluateExpression(doc, e));
+    case "$or": return (expr.$or as any[]).some(e => evaluateExpression(doc, e));
+    case "$not": return !evaluateExpression(doc, expr.$not[0]);
+    case "$cond": {
+      if (Array.isArray(expr.$cond)) {
+        const [condition, thenVal, elseVal] = expr.$cond;
+        return evaluateExpression(doc, condition) ? evaluateExpression(doc, thenVal) : evaluateExpression(doc, elseVal);
+      }
+      const { if: ifExpr, then: thenExpr, else: elseExpr } = expr.$cond;
+      return evaluateExpression(doc, ifExpr) ? evaluateExpression(doc, thenExpr) : evaluateExpression(doc, elseExpr);
+    }
+    case "$ifNull": {
+      const [inputExpr, replacementExpr] = expr.$ifNull;
+      const val = evaluateExpression(doc, inputExpr);
+      return val === null || val === undefined ? evaluateExpression(doc, replacementExpr) : val;
+    }
+    case "$switch": {
+      const branches = expr.$switch.branches;
+      const defaultVal = expr.$switch.default;
+      for (const branch of branches) {
+        if (evaluateExpression(doc, branch.case)) return evaluateExpression(doc, branch.then);
+      }
+      return defaultVal !== undefined ? evaluateExpression(doc, defaultVal) : undefined;
+    }
+
+    case "$arrayElemAt": {
+      const [arr, idx] = expr.$arrayElemAt.map((e: any) => evaluateExpression(doc, e));
+      if (!Array.isArray(arr)) return undefined;
+      return arr[idx < 0 ? arr.length + idx : idx];
+    }
+    case "$arrayToObject": {
+      const arr = evaluateExpression(doc, expr.$arrayToObject);
+      if (!Array.isArray(arr)) return {};
+      const result: Record<string, any> = {};
+      for (const item of arr) {
+        if (Array.isArray(item) && item.length >= 2) result[String(item[0])] = item[1];
+        else if (item && item.k !== undefined) result[String(item.k)] = item.v;
+      }
+      return result;
+    }
+    case "$concatArrays": {
+      const arrays = expr.$concatArrays.map((e: any) => evaluateExpression(doc, e));
+      return arrays.flat();
+    }
+    case "$filter": {
+      const { input, as, cond } = expr.$filter;
+      const arr = evaluateExpression(doc, input);
+      if (!Array.isArray(arr)) return [];
+      const varName = as || "this";
+      return arr.filter(item => evaluateExpression({ ...doc, [varName]: item }, cond));
+    }
+    case "$first": return evaluateExpression(doc, expr.$first);
+    case "$last": return evaluateExpression(doc, expr.$last);
+    case "$size": {
+      const arr = evaluateExpression(doc, expr.$size);
+      return Array.isArray(arr) ? arr.length : 0;
+    }
+    case "$slice": {
+      const args = expr.$slice;
+      const arr = evaluateExpression(doc, args[0]);
+      if (!Array.isArray(arr)) return [];
+      const pos = evaluateExpression(doc, args[1]);
+      if (args[2] !== undefined) return arr.slice(pos, pos + evaluateExpression(doc, args[2]));
+      return arr.slice(0, pos);
+    }
+    case "$map": {
+      const { input, as, in: inExpr } = expr.$map;
+      const arr = evaluateExpression(doc, input);
+      if (!Array.isArray(arr)) return [];
+      const varName = as || "this";
+      return arr.map(item => evaluateExpression({ ...doc, [varName]: item }, inExpr));
+    }
+    case "$reduce": {
+      const { input, initialValue, in: inExpr } = expr.$reduce;
+      const arr = evaluateExpression(doc, input);
+      if (!Array.isArray(arr)) return evaluateExpression(doc, initialValue);
+      const varName = expr.$reduce.as || "this";
+      return arr.reduce((acc, item) => {
+        return evaluateExpression({ ...doc, [varName]: item, value: acc }, inExpr);
+      }, evaluateExpression(doc, initialValue));
+    }
+    case "$range": {
+      const args = expr.$range.map((e: any) => evaluateExpression(doc, e));
+      const [start, end, step = 1] = args;
+      const result: number[] = [];
+      for (let i = start; i < end; i += step) result.push(i);
+      return result;
+    }
+    case "$zip": {
+      const { inputs, useLongestLength, defaults } = expr.$zip;
+      const arrays = inputs.map((e: any) => evaluateExpression(doc, e));
+      const maxLen = useLongestLength ? Math.max(...arrays.map((a: any) => a.length)) : Math.min(...arrays.map((a: any) => a.length));
+      const result: any[][] = [];
+      for (let i = 0; i < maxLen; i++) {
+        const row: any[] = [];
+        for (let j = 0; j < arrays.length; j++) {
+          if (i < arrays[j].length) row.push(arrays[j][i]);
+          else if (defaults && defaults[j] !== undefined) row.push(evaluateExpression(doc, defaults[j]));
+          else row.push(undefined);
+        }
+        result.push(row);
+      }
+      return result;
+    }
+    case "$in": {
+      const [needle, haystack] = expr.$in.map((e: any) => evaluateExpression(doc, e));
+      return Array.isArray(haystack) && haystack.includes(needle);
+    }
+    case "$indexOfArray": {
+      const [arr, searchValue] = expr.$indexOfArray.map((e: any) => evaluateExpression(doc, e));
+      return Array.isArray(arr) ? arr.indexOf(searchValue) : -1;
+    }
+    case "$reverseArray": {
+      const arr = evaluateExpression(doc, expr.$reverseArray);
+      return Array.isArray(arr) ? [...arr].reverse() : [];
+    }
+    case "$sortArray": {
+      const { input, sortBy } = expr.$sortArray;
+      const arr = evaluateExpression(doc, input);
+      if (!Array.isArray(arr)) return [];
+      const sorted = [...arr];
+      if (sortBy === 1) sorted.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+      else if (sortBy === -1) sorted.sort((a, b) => (a > b ? -1 : a < b ? 1 : 0));
+      return sorted;
+    }
+
+    case "$year": return new Date(evaluateExpression(doc, expr.$year)).getFullYear();
+    case "$month": return new Date(evaluateExpression(doc, expr.$month)).getMonth() + 1;
+    case "$dayOfMonth": return new Date(evaluateExpression(doc, expr.$dayOfMonth)).getDate();
+    case "$hour": return new Date(evaluateExpression(doc, expr.$hour)).getHours();
+    case "$minute": return new Date(evaluateExpression(doc, expr.$minute)).getMinutes();
+    case "$second": return new Date(evaluateExpression(doc, expr.$second)).getSeconds();
+    case "$millisecond": return new Date(evaluateExpression(doc, expr.$millisecond)).getMilliseconds();
+    case "$dayOfWeek": return new Date(evaluateExpression(doc, expr.$dayOfWeek)).getDay() + 1;
+    case "$dayOfYear": {
+      const date = new Date(evaluateExpression(doc, expr.$dayOfYear));
+      const start = new Date(date.getFullYear(), 0, 0);
+      return Math.floor((date.getTime() - start.getTime()) / 86400000);
+    }
+    case "$week": return getISOWeek(new Date(evaluateExpression(doc, expr.$week)));
+    case "$isoDayOfWeek": {
+      const day = new Date(evaluateExpression(doc, expr.$isoDayOfWeek)).getDay();
+      return day === 0 ? 7 : day;
+    }
+    case "$isoWeekYear": return getISOWeekYear(new Date(evaluateExpression(doc, expr.$isoWeekYear)));
+    case "$dateToString": {
+      const { format, date, onNull } = expr.$dateToString;
+      const d = evaluateExpression(doc, date);
+      if (d === null || d === undefined) return onNull || null;
+      return formatDate(new Date(d), format || "%Y-%m-%dT%H:%M:%S.%LZ");
+    }
+    case "$dateFromString": {
+      const { dateString, onNull, onError } = expr.$dateFromString;
+      const str = evaluateExpression(doc, dateString);
+      if (str === null || str === undefined) return onNull || null;
+      try { return new Date(str); } catch { return onError || null; }
+    }
+    case "$dateDiff": {
+      const { startDate, endDate, unit } = expr.$dateDiff;
+      return dateDiff(new Date(evaluateExpression(doc, startDate)), new Date(evaluateExpression(doc, endDate)), unit || "day");
+    }
+    case "$dateAdd": {
+      const { startDate, unit, amount } = expr.$dateAdd;
+      return addToDate(new Date(evaluateExpression(doc, startDate)), unit || "day", evaluateExpression(doc, amount));
+    }
+    case "$dateSubtract": {
+      const { startDate, unit, amount } = expr.$dateSubtract;
+      return addToDate(new Date(evaluateExpression(doc, startDate)), unit || "day", -evaluateExpression(doc, amount));
+    }
+    case "$toDate": return new Date(evaluateExpression(doc, expr.$toDate));
+
+    case "$type": {
+      const val = evaluateExpression(doc, expr.$type);
+      if (val === null) return "null";
+      if (val === undefined) return "undefined";
+      if (Array.isArray(val)) return "array";
+      if (val instanceof Date) return "date";
+      if (val instanceof RegExp) return "regex";
+      return typeof val;
+    }
+    case "$convert": {
+      const { input, to, onError, onNull } = expr.$convert;
+      const val = evaluateExpression(doc, input);
+      if (val === null || val === undefined) return onNull !== undefined ? onNull : null;
+      try { return convertType(val, to); } catch { return onError !== undefined ? onError : null; }
+    }
+    case "$toString": {
+      const val = evaluateExpression(doc, expr.$toString);
+      return val !== null && val !== undefined ? String(val) : null;
+    }
+    case "$toInt": {
+      const val = evaluateExpression(doc, expr.$toInt);
+      return val !== null && val !== undefined ? parseInt(val, 10) : null;
+    }
+    case "$toLong": {
+      const val = evaluateExpression(doc, expr.$toLong);
+      return val !== null && val !== undefined ? parseInt(val, 10) : null;
+    }
+    case "$toDouble": {
+      const val = evaluateExpression(doc, expr.$toDouble);
+      return val !== null && val !== undefined ? parseFloat(val) : null;
+    }
+    case "$toBool": {
+      const val = evaluateExpression(doc, expr.$toBool);
+      return val !== null && val !== undefined ? Boolean(val) : null;
+    }
+    case "$toObjectId": return evaluateExpression(doc, expr.$toObjectId);
+    case "$toDecimal": return evaluateExpression(doc, expr.$toDecimal);
+    case "$isNumber": {
+      const val = evaluateExpression(doc, expr.$isNumber);
+      return typeof val === "number" && !isNaN(val);
+    }
+    case "$isArray": return Array.isArray(evaluateExpression(doc, expr.$isArray));
+
+    case "$setEquals": {
+      const sets = expr.$setEquals.map((e: any) => evaluateExpression(doc, e));
+      const [first, ...rest] = sets;
+      const firstSet = new Set(first);
+      return rest.every((arr: any[]) => {
+        const s = new Set(arr);
+        return s.size === firstSet.size && [...firstSet].every(v => s.has(v));
+      });
+    }
+    case "$setIntersection": {
+      const sets = expr.$setIntersection.map((e: any) => evaluateExpression(doc, e));
+      return sets.reduce((a: any[], b: any[]) => a.filter(v => b.includes(v)));
+    }
+    case "$setUnion": {
+      const sets = expr.$setUnion.map((e: any) => evaluateExpression(doc, e));
+      return [...new Set(sets.flat())];
+    }
+    case "$setDifference": {
+      const [a, b] = expr.$setDifference.map((e: any) => evaluateExpression(doc, e));
+      return a.filter((v: any) => !b.includes(v));
+    }
+    case "$setIsSubset": {
+      const [a, b] = expr.$setIsSubset.map((e: any) => evaluateExpression(doc, e));
+      return a.every((v: any) => b.includes(v));
+    }
+    case "$anyElementTrue": {
+      const arr = evaluateExpression(doc, expr.$anyElementTrue);
+      return Array.isArray(arr) && arr.some(v => Boolean(v));
+    }
+    case "$allElementsTrue": {
+      const arr = evaluateExpression(doc, expr.$allElementsTrue);
+      return Array.isArray(arr) && arr.every(v => Boolean(v));
+    }
+
+    case "$literal": return expr.$literal;
+    case "$getField": {
+      const { field, input } = expr.$getField;
+      const obj = input ? evaluateExpression(doc, input) : doc;
+      return obj ? obj[field] : undefined;
+    }
+    case "$mergeObjects": {
+      const sources = Array.isArray(expr.$mergeObjects)
+        ? expr.$mergeObjects.map((e: any) => evaluateExpression(doc, e))
+        : [evaluateExpression(doc, expr.$mergeObjects)];
+      return Object.assign({}, ...sources.filter((s: any) => s !== null && typeof s === "object"));
+    }
+    case "$let": {
+      const { vars, in: inExpr } = expr.$let;
+      const context = { ...doc };
+      for (const [varName, varExpr] of Object.entries(vars)) {
+        context[`$$${varName}`] = evaluateExpression(doc, varExpr);
+      }
+      return evaluateExpression(context, inExpr);
+    }
+
+    default: {
+      const { OperatorRegistry } = require("../OperatorRegistry");
+      const registered = OperatorRegistry.getOperator(op);
+      if (registered && registered.type === "expression") {
+        return (registered.fn as any)(doc, expr[op]);
+      }
+      return expr;
+    }
+  }
+}
+
+function evaluateArithmetic(doc: any, args: any[], op: (a: number, b: number) => number): number {
+  const values = args.map(e => evaluateExpression(doc, e));
+  return values.reduce((a, b) => op(Number(a), Number(b)));
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getISOWeek(date: Date): number {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}
+
+function getISOWeekYear(date: Date): number {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  return d.getUTCFullYear();
+}
+
+function formatDate(date: Date, format: string): string {
+  return format
+    .replace("%Y", String(date.getFullYear()))
+    .replace("%m", String(date.getMonth() + 1).padStart(2, "0"))
+    .replace("%d", String(date.getDate()).padStart(2, "0"))
+    .replace("%H", String(date.getHours()).padStart(2, "0"))
+    .replace("%M", String(date.getMinutes()).padStart(2, "0"))
+    .replace("%S", String(date.getSeconds()).padStart(2, "0"))
+    .replace("%L", String(date.getMilliseconds()).padStart(3, "0"))
+    .replace("%j", String(Math.floor((date.getTime() - new Date(date.getFullYear(), 0, 0).getTime()) / 86400000)));
+}
+
+function dateDiff(start: Date, end: Date, unit: string): number {
+  const diffMs = end.getTime() - start.getTime();
+  switch (unit) {
+    case "millisecond": return diffMs;
+    case "second": return Math.floor(diffMs / 1000);
+    case "minute": return Math.floor(diffMs / 60000);
+    case "hour": return Math.floor(diffMs / 3600000);
+    case "day": return Math.floor(diffMs / 86400000);
+    case "week": return Math.floor(diffMs / 604800000);
+    case "month": return (end.getFullYear() - start.getFullYear()) * 12 + (end.getMonth() - start.getMonth());
+    case "quarter": return Math.floor(((end.getFullYear() - start.getFullYear()) * 12 + (end.getMonth() - start.getMonth())) / 3);
+    case "year": return end.getFullYear() - start.getFullYear();
+    default: return diffMs;
+  }
+}
+
+function addToDate(date: Date, unit: string, amount: number): Date {
+  const result = new Date(date);
+  switch (unit) {
+    case "millisecond": result.setMilliseconds(result.getMilliseconds() + amount); break;
+    case "second": result.setSeconds(result.getSeconds() + amount); break;
+    case "minute": result.setMinutes(result.getMinutes() + amount); break;
+    case "hour": result.setHours(result.getHours() + amount); break;
+    case "day": result.setDate(result.getDate() + amount); break;
+    case "week": result.setDate(result.getDate() + amount * 7); break;
+    case "month": result.setMonth(result.getMonth() + amount); break;
+    case "quarter": result.setMonth(result.getMonth() + amount * 3); break;
+    case "year": result.setFullYear(result.getFullYear() + amount); break;
+  }
+  return result;
+}
+
+function convertType(value: any, to: string): any {
+  switch (to) {
+    case "string": return String(value);
+    case "int": case "long": return parseInt(value, 10);
+    case "double": case "decimal": return parseFloat(value);
+    case "bool": return Boolean(value);
+    case "date": return new Date(value);
+    case "objectId": return value;
+    default: return value;
+  }
+}

--- a/source/Services/Aggregation/operators/stageOperators.ts
+++ b/source/Services/Aggregation/operators/stageOperators.ts
@@ -1,0 +1,521 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { CollectionResolver } from "../../../config/Interfaces/Operation/aggregation.interface";
+import { evaluateExpression, getNestedValue } from "./expressionOperators";
+import { BUILT_IN_ACCUMULATORS } from "./accumulatorOperators";
+import { OperatorRegistry } from "../OperatorRegistry";
+
+function matchesCondition(itemValue: any, condition: any): boolean {
+  if (condition === null || condition === undefined) {
+    return itemValue === null || itemValue === undefined;
+  }
+
+  if (typeof condition === "string" || typeof condition === "number" || typeof condition === "boolean") {
+    return itemValue === condition;
+  }
+
+  if (condition instanceof RegExp) return condition.test(String(itemValue));
+
+  if (typeof condition === "object") {
+    if ("$regex" in condition) {
+      try {
+        return new RegExp(String(condition.$regex), condition.$options || "").test(String(itemValue));
+      } catch { return false; }
+    }
+    if ("$gte" in condition) return itemValue >= condition.$gte;
+    if ("$gt" in condition) return itemValue > condition.$gt;
+    if ("$lte" in condition) return itemValue <= condition.$lte;
+    if ("$lt" in condition) return itemValue < condition.$lt;
+    if ("$ne" in condition) return itemValue !== condition.$ne;
+    if ("$in" in condition) return Array.isArray(condition.$in) && condition.$in.includes(itemValue);
+    if ("$nin" in condition) return Array.isArray(condition.$nin) && !condition.$nin.includes(itemValue);
+    if ("$exists" in condition) return condition.$exists ? itemValue !== undefined : itemValue === undefined;
+    if ("$not" in condition) return !matchesCondition(itemValue, condition.$not);
+    if ("$elemMatch" in condition) {
+      return Array.isArray(itemValue) && itemValue.some(elem => matchesDocument(elem, condition.$elemMatch));
+    }
+    if ("$all" in condition) return Array.isArray(itemValue) && condition.$all.every((v: any) => itemValue.includes(v));
+    if ("$size" in condition) return Array.isArray(itemValue) && itemValue.length === condition.$size;
+    if ("$type" in condition) return matchesType(itemValue, condition.$type);
+    if ("$mod" in condition) {
+      const [divisor, remainder] = condition.$mod;
+      return itemValue % divisor === remainder;
+    }
+  }
+
+  return false;
+}
+
+function matchesType(value: any, type: string | number): boolean {
+  if (typeof type === "number") {
+    switch (type) {
+      case 1: return typeof value === "number" && !isNaN(value);
+      case 2: return typeof value === "string";
+      case 3: return typeof value === "object" && value !== null && !Array.isArray(value);
+      case 4: return Array.isArray(value);
+      case 8: return typeof value === "boolean";
+      case 9: return value instanceof Date;
+      case 10: return value === null;
+      default: return false;
+    }
+  }
+  switch (type) {
+    case "number": return typeof value === "number" && !isNaN(value);
+    case "string": return typeof value === "string";
+    case "object": return typeof value === "object" && value !== null && !Array.isArray(value);
+    case "array": return Array.isArray(value);
+    case "bool": return typeof value === "boolean";
+    case "date": return value instanceof Date;
+    case "null": return value === null;
+    case "undefined": return value === undefined;
+    default: return false;
+  }
+}
+
+function matchesDocument(item: any, query: any): boolean {
+  return Object.entries(query).every(([key, value]) => {
+    if (key === "$and") return Array.isArray(value) && value.every((cond: any) => matchesDocument(item, cond));
+    if (key === "$or") return Array.isArray(value) && value.some((cond: any) => matchesDocument(item, cond));
+    if (key === "$nor") return Array.isArray(value) && !value.some((cond: any) => matchesDocument(item, cond));
+    if (key === "$not") return typeof value === "object" && !matchesDocument(item, value);
+    return matchesCondition(getNestedValue(item, key), value);
+  });
+}
+
+export function executeMatch(input: any[], matchExpr: any): any[] {
+  return input.filter(item => matchesDocument(item, matchExpr));
+}
+
+export function executeGroup(input: any[], groupExpr: any): any[] {
+  const groupedData: Record<string, any> = {};
+
+  for (const item of input) {
+    let groupKey: string;
+
+    if (groupExpr._id === null || groupExpr._id === undefined) {
+      groupKey = "null";
+    } else if (typeof groupExpr._id === "string") {
+      groupKey = String(groupExpr._id.startsWith("$") ? getNestedValue(item, groupExpr._id.substring(1)) : groupExpr._id);
+    } else if (typeof groupExpr._id === "object") {
+      const keyObj: Record<string, any> = {};
+      for (const [k, v] of Object.entries(groupExpr._id)) {
+        if (typeof v === "string" && v.startsWith("$")) keyObj[k] = getNestedValue(item, v.substring(1));
+        else if (typeof v === "object" && v !== null) keyObj[k] = evaluateExpression(item, v);
+        else keyObj[k] = v;
+      }
+      groupKey = JSON.stringify(keyObj);
+    } else {
+      groupKey = String(groupExpr._id);
+    }
+
+    if (!groupedData[groupKey]) {
+      groupedData[groupKey] = { _id: groupExpr._id === null ? null : (typeof groupExpr._id === "object" ? JSON.parse(groupKey) : groupKey) };
+    }
+
+    for (const [key, operation] of Object.entries(groupExpr) as [string, any][]) {
+      if (key === "_id") continue;
+      if (typeof operation !== "object" || operation === null) continue;
+
+      const accOp = Object.keys(operation)[0];
+      const accExpr = operation[accOp];
+      const isBuiltIn = !!BUILT_IN_ACCUMULATORS[accOp];
+      const isCustom = !isBuiltIn && OperatorRegistry.getOperator(accOp)?.type === "accumulator";
+
+      if (isBuiltIn || isCustom) {
+        if (!groupedData[groupKey][`__acc_${key}`]) groupedData[groupKey][`__acc_${key}`] = [];
+        groupedData[groupKey][`__acc_${key}`].push(item);
+        groupedData[groupKey][`__acc_expr_${key}`] = { op: accOp, expr: accExpr, custom: isCustom };
+      }
+    }
+  }
+
+  return Object.values(groupedData).map(group => {
+    const result: any = { _id: group._id };
+    for (const key of Object.keys(group)) {
+      if (!key.startsWith("__acc_") || key.startsWith("__acc_expr_")) continue;
+      const fieldKey = key.replace("__acc_", "");
+      const accInfo = group[`__acc_expr_${fieldKey}`];
+      const docs = group[key];
+
+      if (accInfo.custom) {
+        const registered = OperatorRegistry.getOperator(accInfo.op);
+        if (registered) result[fieldKey] = (registered.fn as any)(docs, accInfo.expr);
+      } else {
+        const accFn = BUILT_IN_ACCUMULATORS[accInfo.op];
+        if (accFn) result[fieldKey] = accFn(docs, accInfo.expr);
+      }
+    }
+    return result;
+  });
+}
+
+export function executeSort(input: any[], sortExpr: Record<string, 1 | -1>): any[] {
+  const sortFields = Object.entries(sortExpr);
+  return [...input].sort((a, b) => {
+    for (const [field, order] of sortFields) {
+      const aVal = getNestedValue(a, field);
+      const bVal = getNestedValue(b, field);
+      if (aVal < bVal) return -order;
+      if (aVal > bVal) return order;
+    }
+    return 0;
+  });
+}
+
+export function executeProject(input: any[], projectExpr: Record<string, any>): any[] {
+  const hasInclusion = Object.values(projectExpr).some(v => v === 1 || (typeof v === "object" && v !== null));
+  const hasExclusion = Object.values(projectExpr).some(v => v === 0);
+
+  return input.map(item => {
+    if (hasExclusion && !hasInclusion) {
+      const result = { ...item };
+      for (const [key, val] of Object.entries(projectExpr)) {
+        if (val === 0) delete result[key];
+      }
+      return result;
+    }
+
+    const result: Record<string, any> = {};
+    if (projectExpr._id !== 0 && item._id !== undefined) result._id = item._id;
+    for (const [key, val] of Object.entries(projectExpr)) {
+      if (key === "_id") continue;
+      if (val === 1) result[key] = item[key];
+      else if (typeof val === "object" && val !== null) result[key] = evaluateExpression(item, val);
+      else if (typeof val === "string" && val.startsWith("$")) result[key] = getNestedValue(item, val.substring(1));
+    }
+    return result;
+  });
+}
+
+export function executeLimit(input: any[], limit: number): any[] {
+  return input.slice(0, limit);
+}
+
+export function executeSkip(input: any[], skip: number): any[] {
+  return input.slice(skip);
+}
+
+export function executeUnwind(input: any[], unwindExpr: string | { path: string; includeArrayIndex?: string; preserveNullAndEmptyArrays?: boolean }): any[] {
+  let fieldPath: string;
+  let includeArrayIndex: string | undefined;
+  let preserveNull = false;
+
+  if (typeof unwindExpr === "string") {
+    fieldPath = unwindExpr.startsWith("$") ? unwindExpr.substring(1) : unwindExpr;
+  } else {
+    fieldPath = unwindExpr.path.startsWith("$") ? unwindExpr.path.substring(1) : unwindExpr.path;
+    includeArrayIndex = unwindExpr.includeArrayIndex;
+    preserveNull = unwindExpr.preserveNullAndEmptyArrays || false;
+  }
+
+  const result: any[] = [];
+  for (const item of input) {
+    const value = getNestedValue(item, fieldPath);
+
+    if (Array.isArray(value)) {
+      if (value.length === 0 && preserveNull) {
+        const doc = { ...item };
+        setNestedValue(doc, fieldPath, null);
+        if (includeArrayIndex) doc[includeArrayIndex] = null;
+        result.push(doc);
+      }
+      value.forEach((val, index) => {
+        const doc = { ...item };
+        setNestedValue(doc, fieldPath, val);
+        if (includeArrayIndex) doc[includeArrayIndex] = index;
+        result.push(doc);
+      });
+    } else if ((value === null || value === undefined) && preserveNull) {
+      const doc = { ...item };
+      setNestedValue(doc, fieldPath, null);
+      if (includeArrayIndex) doc[includeArrayIndex] = null;
+      result.push(doc);
+    } else if (value !== null && value !== undefined) {
+      result.push(item);
+    }
+  }
+  return result;
+}
+
+function setNestedValue(obj: any, path: string, value: any): void {
+  const parts = path.split(".");
+  let current = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (current[parts[i]] === undefined) current[parts[i]] = {};
+    current = current[parts[i]];
+  }
+  current[parts[parts.length - 1]] = value;
+}
+
+export function executeAddFields(input: any[], addFieldsExpr: Record<string, any>): any[] {
+  return input.map(item => {
+    const result = { ...item };
+    for (const [key, expr] of Object.entries(addFieldsExpr)) {
+      result[key] = evaluateExpression(item, expr);
+    }
+    return result;
+  });
+}
+
+export function executeUnset(input: any[], unsetExpr: string | string[]): any[] {
+  const fields = Array.isArray(unsetExpr) ? unsetExpr : [unsetExpr];
+  return input.map(item => {
+    const result = { ...item };
+    for (const field of fields) delete result[field];
+    return result;
+  });
+}
+
+export function executeCount(input: any[], countExpr: string): any[] {
+  return [{ [countExpr]: input.length }];
+}
+
+export function executeSortByCount(input: any[], expr: any): any[] {
+  const grouped: Record<string, number> = {};
+  for (const item of input) {
+    let key: any;
+    if (typeof expr === "string" && expr.startsWith("$")) key = getNestedValue(item, expr.substring(1));
+    else if (typeof expr === "object" && expr !== null) key = evaluateExpression(item, expr);
+    else key = expr;
+    const strKey = JSON.stringify(key);
+    grouped[strKey] = (grouped[strKey] || 0) + 1;
+  }
+  return Object.entries(grouped)
+    .map(([k, count]) => ({ _id: JSON.parse(k), count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+export function executeSample(input: any[], sampleExpr: { size: number }): any[] {
+  const size = Math.min(sampleExpr.size, input.length);
+  const shuffled = [...input];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled.slice(0, size);
+}
+
+export function executeFacet(input: any[], facetExpr: Record<string, any[]>): Record<string, any[]> {
+  const result: Record<string, any[]> = {};
+  for (const [key, pipeline] of Object.entries(facetExpr)) {
+    let stageResult = [...input];
+    for (const stage of pipeline) {
+      const opName = Object.keys(stage)[0];
+      stageResult = executeStageSync(opName, stageResult, (stage as any)[opName]);
+    }
+    result[key] = stageResult;
+  }
+  return result;
+}
+
+function executeStageSync(opName: string, input: any[], expr: any): any[] {
+  switch (opName) {
+    case "$match": return executeMatch(input, expr);
+    case "$group": return executeGroup(input, expr);
+    case "$sort": return executeSort(input, expr);
+    case "$project": return executeProject(input, expr);
+    case "$limit": return executeLimit(input, expr);
+    case "$skip": return executeSkip(input, expr);
+    case "$unwind": return executeUnwind(input, expr);
+    case "$addFields": case "$set": return executeAddFields(input, expr);
+    case "$unset": return executeUnset(input, expr);
+    case "$count": return executeCount(input, expr);
+    case "$sortByCount": return executeSortByCount(input, expr);
+    case "$sample": return executeSample(input, expr);
+    case "$replaceRoot": case "$replaceWith": return executeReplaceRoot(input, expr);
+    default: return input;
+  }
+}
+
+export function executeBucket(input: any[], bucketExpr: { groupBy: any; boundaries: any[]; default?: string; output?: Record<string, any> }): any[] {
+  const { groupBy, boundaries, default: defaultKey = "Other", output } = bucketExpr;
+  const buckets: Record<string, any[]> = {};
+
+  for (let i = 0; i < boundaries.length - 1; i++) {
+    buckets[JSON.stringify({ min: boundaries[i], max: boundaries[i + 1] })] = [];
+  }
+  buckets[JSON.stringify(defaultKey)] = [];
+
+  for (const item of input) {
+    let value: any;
+    if (typeof groupBy === "string" && groupBy.startsWith("$")) value = getNestedValue(item, groupBy.substring(1));
+    else if (typeof groupBy === "object") value = evaluateExpression(item, groupBy);
+    else value = groupBy;
+
+    let placed = false;
+    for (let i = 0; i < boundaries.length - 1; i++) {
+      if (value >= boundaries[i] && value < boundaries[i + 1]) {
+        buckets[JSON.stringify({ min: boundaries[i], max: boundaries[i + 1] })].push(item);
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) buckets[JSON.stringify(defaultKey)].push(item);
+  }
+
+  return Object.entries(buckets)
+    .filter(([, docs]) => docs.length > 0)
+    .map(([key, docs]) => {
+      const parsedKey = JSON.parse(key);
+      const result: any = { _id: parsedKey };
+      if (output) {
+        for (const [field, accExpr] of Object.entries(output)) {
+          const accOp = Object.keys(accExpr)[0];
+          const accFn = BUILT_IN_ACCUMULATORS[accOp];
+          if (accFn) result[field] = accFn(docs, (accExpr as any)[accOp]);
+        }
+      } else {
+        result.count = docs.length;
+      }
+      return result;
+    });
+}
+
+export function executeBucketAuto(input: any[], bucketExpr: { groupBy: any; buckets: number; output?: Record<string, any> }): any[] {
+  const { groupBy, buckets: numBuckets, output } = bucketExpr;
+
+  const itemsWithValue = input.map(item => {
+    let value: any;
+    if (typeof groupBy === "string" && groupBy.startsWith("$")) value = getNestedValue(item, groupBy.substring(1));
+    else if (typeof groupBy === "object") value = evaluateExpression(item, groupBy);
+    else value = groupBy;
+    return { item, value };
+  }).sort((a, b) => (a.value < b.value ? -1 : a.value > b.value ? 1 : 0));
+
+  const bucketSize = Math.ceil(itemsWithValue.length / numBuckets);
+  const result: any[] = [];
+
+  for (let i = 0; i < numBuckets && i * bucketSize < itemsWithValue.length; i++) {
+    const bucketItems = itemsWithValue.slice(i * bucketSize, (i + 1) * bucketSize);
+    const docs = bucketItems.map(b => b.item);
+
+    const bucketResult: any = { _id: { min: bucketItems[0].value, max: bucketItems[bucketItems.length - 1].value } };
+    if (output) {
+      for (const [field, accExpr] of Object.entries(output)) {
+        const accOp = Object.keys(accExpr)[0];
+        const accFn = BUILT_IN_ACCUMULATORS[accOp];
+        if (accFn) bucketResult[field] = accFn(docs, (accExpr as any)[accOp]);
+      }
+    } else {
+      bucketResult.count = docs.length;
+    }
+    result.push(bucketResult);
+  }
+
+  return result;
+}
+
+export function executeReplaceRoot(input: any[], expr: { newRoot: any }): any[] {
+  return input.map(item => {
+    if (typeof expr.newRoot === "string" && expr.newRoot.startsWith("$")) {
+      return getNestedValue(item, expr.newRoot.substring(1)) || {};
+    }
+    return evaluateExpression(item, expr.newRoot);
+  });
+}
+
+export async function executeLookup(input: any[], lookupExpr: any, resolver?: CollectionResolver): Promise<any[]> {
+  if (!resolver) {
+    throw new Error("$lookup requires a collection resolver. Ensure the collection was created via Database.createCollection().");
+  }
+
+  const { from, localField, foreignField, as, let: letExpr, pipeline: lookupPipeline } = lookupExpr;
+
+  if (!from) throw new Error("$lookup requires a 'from' field specifying the foreign collection name.");
+  if (!as) throw new Error("$lookup requires an 'as' field specifying the output array field name.");
+
+  let foreignData: any[];
+
+  if (lookupPipeline) {
+    // Pipeline $lookup: extract $match from pipeline as index hint
+    const queryHint = extractMatchFromPipeline(lookupPipeline);
+    try {
+      foreignData = await resolver(from, queryHint);
+    } catch (error) {
+      throw new Error(`$lookup failed to load collection "${from}": ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    return input.map(doc => {
+      const boundVars: Record<string, any> = {};
+      if (letExpr) {
+        for (const [varName, varExpr] of Object.entries(letExpr)) {
+          boundVars[`$$${varName}`] = typeof varExpr === "string" && varExpr.startsWith("$")
+            ? getNestedValue(doc, varExpr.substring(1))
+            : evaluateExpression(doc, varExpr);
+        }
+      }
+
+      let matched = [...foreignData];
+      for (const stage of lookupPipeline) {
+        const opName = Object.keys(stage)[0];
+        matched = executeStageSync(opName, matched, resolveVariables((stage as any)[opName], boundVars));
+      }
+
+      return { ...doc, [as]: matched };
+    });
+  }
+
+  if (localField && foreignField) {
+    // Equality $lookup: collect distinct values, use $in as index hint
+    const distinctValues = [...new Set(input.map(doc => getNestedValue(doc, localField)).filter(v => v !== undefined))];
+    const queryHint = distinctValues.length > 0 ? { [foreignField]: { $in: distinctValues } } : undefined;
+
+    try {
+      foreignData = await resolver(from, queryHint);
+    } catch (error) {
+      throw new Error(`$lookup failed to load collection "${from}": ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    return input.map(doc => {
+      const localValue = getNestedValue(doc, localField);
+      return { ...doc, [as]: foreignData.filter(foreignDoc => getNestedValue(foreignDoc, foreignField) === localValue) };
+    });
+  }
+
+  throw new Error("$lookup requires either (localField + foreignField) or (pipeline) for join conditions.");
+}
+
+export function extractMatchFromPipeline(pipeline: any[]): Record<string, any> | undefined {
+  for (const stage of pipeline) {
+    if (stage && typeof stage === "object" && stage.$match) {
+      return stage.$match;
+    }
+  }
+  return undefined;
+}
+
+function resolveVariables(expr: any, vars: Record<string, any>): any {
+  if (typeof expr === "string") {
+    if (expr.startsWith("$$") && vars[expr] !== undefined) return vars[expr];
+    return expr;
+  }
+  if (Array.isArray(expr)) return expr.map(item => resolveVariables(item, vars));
+  if (typeof expr === "object" && expr !== null) {
+    const result: Record<string, any> = {};
+    for (const [key, value] of Object.entries(expr)) result[key] = resolveVariables(value, vars);
+    return result;
+  }
+  return expr;
+}
+
+export function executeMergeObjects(input: any[]): any[] {
+  if (input.length === 0) return [];
+  return input.reduce((merged, doc) => ({ ...merged, ...doc }), {});
+}
+
+export const BUILT_IN_STAGE_OPERATORS: Record<string, (input: any[], expr: any) => any[]> = {
+  $match: executeMatch,
+  $group: executeGroup,
+  $sort: executeSort,
+  $project: executeProject,
+  $limit: executeLimit,
+  $skip: executeSkip,
+  $unwind: executeUnwind,
+  $addFields: executeAddFields,
+  $set: executeAddFields,
+  $unset: executeUnset,
+  $count: executeCount,
+  $sortByCount: executeSortByCount,
+  $sample: executeSample,
+  $replaceRoot: executeReplaceRoot,
+  $replaceWith: executeReplaceRoot,
+};

--- a/source/Services/Collection/collection.operation.ts
+++ b/source/Services/Collection/collection.operation.ts
@@ -4,6 +4,7 @@ import {
   SuccessInterface,
 } from "../../config/Interfaces/Helper/response.helper.interface";
 import { SessionOptions } from "../../config/Interfaces/Transaction/transaction.interface";
+import { CollectionResolver } from "../../config/Interfaces/Operation/aggregation.interface";
 import ResponseHelper from "../../Helper/response.helper";
 // Operations
 import Reader from "../CRUD Operation/Reader.operation";
@@ -32,16 +33,19 @@ export default class Collection {
   private Converter: Converter;
   private readonly IndexManager: IndexManager;
   private readonly indexCache: IndexCache;
+  private readonly collectionResolver?: CollectionResolver;
 
   constructor(
     name: string,
     path: string,
+    collectionResolver?: CollectionResolver,
   ) {
     this.name = name;
     this.path = path;
     this.Converter = new Converter();
     this.updatedAt = new Date().toISOString();
     this.IndexManager = new IndexManager(this.path);
+    this.collectionResolver = collectionResolver;
 
     // Initialize and eagerly load index cache for maximum query performance
     this.indexCache = IndexCache.getInstance(this.path);
@@ -245,6 +249,7 @@ export default class Collection {
       this.name,
       this.path,
       PipelineQuerySteps,
+      this.collectionResolver,
     );
   }
 

--- a/source/Services/Database/database.operation.ts
+++ b/source/Services/Database/database.operation.ts
@@ -11,9 +11,11 @@ import {
   SuccessInterface,
 } from "../../config/Interfaces/Helper/response.helper.interface";
 import { FinalCollectionsInfo } from "../../config/Interfaces/Operation/database.operation.interface";
+import { CollectionResolver } from "../../config/Interfaces/Operation/aggregation.interface";
 import { IndexManager } from "../Index/Index.service";
 import { IndexCache } from "../Index/IndexCache.service";
 import { General } from "../../config/Keys/Keys";
+import DocumentLoader from "../../Helper/DocumentLoader.helper";
 
 // Types
 type CollectionMetadata = {
@@ -69,7 +71,8 @@ export default class Database {
     const Index = new IndexManager(collectionPath);
     await Index.generateIndexMeta();
 
-    const collection = new Collection(collectionName, collectionPath);
+    const resolver = this.createCollectionResolver();
+    const collection = new Collection(collectionName, collectionPath, resolver);
     // Store collection metadata in the collectionMap
     await this.AddCollectionMetadata({
       name: collectionName,
@@ -264,5 +267,44 @@ export default class Database {
     return (await this.readCollectionMetadata()).find(
       (data: CollectionMetadata) => data.name === collectionName,
     );
+  }
+
+  /**
+   * Creates a collection resolver function for cross-collection data access.
+   * Used by $lookup to load documents from sibling collections within the same database.
+   *
+   * @returns A CollectionResolver function that loads all documents from a named collection
+   * @private
+   */
+  private createCollectionResolver(): CollectionResolver {
+    return async (targetCollectionName: string, query?: Record<string, any>): Promise<any[]> => {
+      const sanitizedTarget = PathSanitizer.sanitizePathComponent(targetCollectionName);
+      const targetPath = PathSanitizer.safePath(this.path, sanitizedTarget);
+
+      const exists = await this.folderManager.DirectoryExists(targetPath);
+      if (exists.statusCode !== StatusCodes.OK) {
+        throw new Error(
+          `Collection "${targetCollectionName}" does not exist in database "${this.name}"`,
+        );
+      }
+
+      // Try index-optimized load when query is provided
+      if (query && Object.keys(query).length > 0) {
+        try {
+          const { ReadIndex } = await import("../Index/ReadIndex.service");
+          const fileNames = await new ReadIndex(targetPath).getFileFromIndex(query);
+          if (fileNames.length > 0) {
+            const result = await DocumentLoader.loadDocuments(targetPath, fileNames, false);
+            if ("data" in result) return result.data;
+          }
+        } catch {
+          // Index miss — fall through to full scan
+        }
+      }
+
+      const result = await DocumentLoader.loadDocuments(targetPath);
+      if ("data" in result) return result.data;
+      throw new Error(`Failed to load documents from collection "${targetCollectionName}"`);
+    };
   }
 }

--- a/source/config/DB.ts
+++ b/source/config/DB.ts
@@ -2,6 +2,7 @@ import { InMemoryCache } from "../Memory/memory.operation";
 import Converter from "../Helper/Converter.helper";
 import ResponseHelper from "../Helper/response.helper";
 import Aggregation from "../Services/Aggregation/Aggregation.Operation";
+import { OperatorRegistry } from "../Services/Aggregation/OperatorRegistry";
 import Collection from "../Services/Collection/collection.operation";
 import Database from "../Services/Database/database.operation";
 import { AxioDB } from "../Services/Indexation.operation";
@@ -13,6 +14,7 @@ const InstanceTypes = {
   Collection,
   Database,
   Aggregation,
+  OperatorRegistry,
   FileManager,
   FolderManager,
   Converter,
@@ -20,10 +22,11 @@ const InstanceTypes = {
   InMemoryCache,
 };
 
-export { AxioDB, AxioDBCloud, InstanceTypes };
+export { AxioDB, AxioDBCloud, InstanceTypes, OperatorRegistry };
 
 export default {
   AxioDB,
   AxioDBCloud,
   InstanceTypes,
+  OperatorRegistry,
 };

--- a/source/config/Interfaces/Operation/aggregation.interface.ts
+++ b/source/config/Interfaces/Operation/aggregation.interface.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export type CollectionResolver = (collectionName: string, query?: Record<string, any>) => Promise<any[]>;
+
+export type StageOperatorFn = (input: any[], stageExpr: any, resolver?: CollectionResolver) => any[] | Promise<any[]>;
+
+export type AccumulatorFn = (collection: any[], expr: any) => any;
+
+export type ExpressionFn = (doc: any, expr: any) => any;
+
+export interface RegisteredOperator {
+  type: "stage" | "accumulator" | "expression";
+  name: string;
+  fn: StageOperatorFn | AccumulatorFn | ExpressionFn;
+}


### PR DESCRIPTION
#331 

# feat: Aggregation engine rewrite — 60+ operators, $lookup, custom operator registry

Closes #331

## Summary

Complete rewrite of the aggregation pipeline engine. Adds cross-collection `$lookup` joins, a custom operator registration system (`OperatorRegistry`), a full expression evaluator (80+ operators), and expands from 8 pipeline stages to 60+. Zero new dependencies — everything is pure TypeScript.

## What changed

### New features

- **`$lookup`** — Cross-collection joins. Equality form (`localField`/`foreignField`) and pipeline form (`let`/`pipeline` with `$$var` binding). Foreign collection data loaded via a resolver function threaded from Database → Collection → Aggregation. Index-optimized: equality joins pass distinct values as `$in` query hints, pipeline joins extract `$match` conditions as hints.

- **`OperatorRegistry`** — Static class for registering custom stage operators, accumulators, and expression operators. Custom operators merge with built-ins at pipeline execution time.

  ```typescript
  OperatorRegistry.registerStageOperator("$myStage", (input, expr) => { ... });
  OperatorRegistry.registerAccumulator("$median", (collection, expr) => { ... });
  OperatorRegistry.registerExpressionOperator("$reverse", (doc, expr) => { ... });
  ```

- **Expression evaluator** — 80+ operators: arithmetic (`$add`, `$subtract`, `$multiply`, `$divide`, `$mod`, `$abs`, `$ceil`, `$floor`, `$sqrt`, `$pow`, `$round`), string (`$concat`, `$substr`, `$toLower`, `$toUpper`, `$trim`, `$split`, `$replaceOne`, `$replaceAll`, `$regexMatch`), comparison (`$eq`, `$gt`, `$gte`, `$lt`, `$lte`, `$ne`, `$cmp`), logical (`$and`, `$or`, `$not`, `$cond`, `$ifNull`, `$switch`), array (`$filter`, `$map`, `$reduce`, `$arrayElemAt`, `$concatArrays`, `$size`, `$slice`, `$range`, `$sortArray`, `$reverseArray`, `$zip`), date (`$year`, `$month`, `$dayOfMonth`, `$hour`, `$minute`, `$second`, `$dayOfWeek`, `$dayOfYear`, `$week`, `$dateToString`, `$dateFromString`, `$dateDiff`, `$dateAdd`, `$dateSubtract`), type (`$type`, `$convert`, `$toString`, `$toInt`, `$toDouble`, `$toBool`, `$isNumber`, `$isArray`), set (`$setEquals`, `$setIntersection`, `$setUnion`, `$setDifference`, `$setIsSubset`), misc (`$literal`, `$getField`, `$mergeObjects`, `$let`).

- **New pipeline stages**: `$lookup`, `$facet`, `$bucket`, `$bucketAuto`, `$count`, `$sortByCount`, `$sample`, `$replaceRoot`/`$replaceWith`, `$set`, `$unset`.

- **New accumulators**: `$min`, `$max`, `$first`, `$last`, `$push`, `$addToSet`, `$stdDevPop`, `$stdDevSamp` (previously only `$sum` and `$avg`).

### Enhancements

- **`$match`** — Now supports top-level logical operators (`$and`, `$or`, `$nor`, `$not`), `$exists`, `$elemMatch`, `$all`, `$size`, `$type`, `$mod`. No longer required as the first stage.
- **`$sort`** — Multi-field sorting (`{ department: 1, salary: -1 }`).
- **`$project`** — Exclusion mode (`{ field: 0 }`) and computed fields via expressions (`{ bonus: { $multiply: ['$salary', 0.1] } }`).
- **`$addFields`** — Computed expressions instead of only literal values.
- **`$unwind`** — Object form with `includeArrayIndex` and `preserveNullAndEmptyArrays`.
- **Index optimization** — Scans entire pipeline for `$match` (not just index 0) and uses it for index-aware loading regardless of position.
- **`$lookup` index optimization** — Foreign collection uses `ReadIndex` when query hints are available.

### Bug fixes

- Fixed index lookup in aggregation (accessed `this.Pipeline.$match` instead of `this.Pipeline[0].$match`).

## Files changed

| File | Action | Description |
|------|--------|-------------|
| `source/config/Interfaces/Operation/aggregation.interface.ts` | Create | `CollectionResolver`, operator function types |
| `source/Services/Aggregation/Aggregation.Operation.ts` | Rewrite | New engine with resolver support |
| `source/Services/Aggregation/OperatorRegistry.ts` | Create | Custom operator registry |
| `source/Services/Aggregation/operators/expressionOperators.ts` | Create | Expression evaluator |
| `source/Services/Aggregation/operators/accumulatorOperators.ts` | Create | Accumulator operators |
| `source/Services/Aggregation/operators/stageOperators.ts` | Create | Stage operators with $lookup |
| `source/Services/Collection/collection.operation.ts` | Modify | Accept optional resolver |
| `source/Services/Database/database.operation.ts` | Modify | Create resolver with index support |
| `source/config/DB.ts` | Modify | Export `OperatorRegistry` |
| `Test/modules/aggregation.test.js` | Create | 63 test cases |
| `Test/run.js` | Modify | Register aggregation suite |
| `README.md` | Modify | Updated feature list and comparison table |
| `Document/src/data/changelog.ts` | Modify | v15.1.0 changelog entry |
| `Document/public/llms-full.txt` | Modify | Aggregation section + limitations |
| `Document/public/.well-known/agent-skills/axiodb/SKILL.md` | Modify | Aggregation description + limits |
| `Document/src/components/content/ApiReference.tsx` | Modify | Full API docs rewrite |
| `Document/src/components/content/AdvancedFeatures.tsx` | Modify | $lookup and $facet examples |
| `Document/src/components/content/Features.tsx` | Modify | Feature card update |
| `Document/src/components/content/Usage.tsx` | Modify | Usage examples with $lookup |
| `GUI/src/components/query/queryLanguage.js` | Modify | Autocomplete: 8 → 27 entries |
| `Docker/mcp/tools/document.tools.js` | Modify | MCP tool description |

## Architecture

```
Database.createCollection("Users")
  └── creates resolver: (name, query?) => ReadIndex + DocumentLoader
        └── Collection stores resolver
              └── aggregate(pipeline) passes resolver to Aggregation
                    └── exec() loads source data, executes stages sequentially
                          └── $lookup calls resolver with query hints
```

## Testing

63 new test cases in `Test/modules/aggregation.test.js`:

- **13** backward compatibility (existing 8 operators)
- **14** enhanced operators ($or, $and, $not, $exists, multi-sort, $project exclusion, accumulators)
- **9** new stages ($count, $sortByCount, $sample, $set, $unset, $replaceRoot, $facet, $bucket, $bucketAuto)
- **6** $lookup (equality join, $unwind, $match on joined, $group on joined, error cases)
- **8** expression evaluator ($add, $subtract, $multiply, $cond, $concat, $toLower, $ifNull, computed $addFields)
- **5** custom operators (register stage/accumulator/expression, clearAll, validation)
- **6** edge cases (empty collection, invalid pipeline, empty pipeline, $match not first, complex pipeline, nested fields)
- **3** pipeline flexibility (start with $group, $sort, $project)

All 10 test suites pass (crud, transaction, read, aggregation, auth, tcp-auth, tcp-noauth, tcp-tls, crash-recovery, mcp-confirm).

## Breaking changes

None. The existing `collection.aggregate([...]).exec()` API is fully backward compatible. The `$match`-must-be-first restriction is lifted (pipelines that started with `$match` still work, but it's no longer required).

## Checklist

- [x] `npm run build` passes
- [x] `npm test` passes (all 10 suites)
- [x] Tests added/updated in `Test/modules/`
- [x] Docs updated (README, Document/, changelog, llms-full.txt, SKILL.md)
- [x] GUI autocomplete updated
- [x] MCP tool description updated
- [x] No `any` abuse; patterns followed (singleton, dual-write, resolver threading)
- [x] Security validated (path sanitization in resolver, input validation)
- [x] No breaking changes
