### PR TITLE
fix: Update GitHub API owner to Nexoral

### DIFF
--- a/Document/src/services/githubApi.ts
+++ b/Document/src/services/githubApi.ts
@@ -55,7 +55,7 @@ interface GitHubUser {
 
 class GitHubApiService {
   private baseUrl = 'https://api.github.com';
-  private owner = 'AnkanSaha';
+  private owner = 'Nexoral';
   private repo = 'AxioDB';
 
   private async fetchFromGitHub<T>(endpoint: string): Promise<T> {


### PR DESCRIPTION
This pull request makes a small change to the `GitHubApiService` class by updating the repository owner from `'AnkanSaha'` to `'Nexoral'`. This ensures API requests are directed to the correct GitHub organization.