### PR TITLE
feat: Update Introduction component and changelog for AxioDB CLI release

### DIFF
--- a/Document/src/components/content/Introduction.tsx
+++ b/Document/src/components/content/Introduction.tsx
@@ -202,9 +202,7 @@ const Introduction: React.FC = () => {
           {/* New Feature Banner: CLI */}
           <a
             ref={cliBannerReveal.ref}
-            href="https://github.com/nexoral/AxioDB/releases?q=cli-v&expanded=true"
-            target="_blank"
-            rel="noopener noreferrer"
+            href="/cli"
             className={`group flex flex-col sm:flex-row items-start sm:items-center gap-4 bg-emerald-50 px-6 py-5 rounded-xl border-2 border-emerald-200 shadow-md hover:shadow-lg transition-all duration-300 mb-8 reveal-on-scroll ${cliBannerReveal.isVisible ? "is-visible" : ""}`}
           >
             <div className="flex items-center justify-center w-12 h-12 bg-emerald-600 rounded-xl shadow-lg group-hover:scale-110 transition-transform duration-300 flex-shrink-0">

--- a/Document/src/data/changelog.ts
+++ b/Document/src/data/changelog.ts
@@ -12,6 +12,25 @@ export interface ChangelogEntry {
  */
 export const changelog: ChangelogEntry[] = [
   {
+    version: "15.2.0",
+    date: "2026-08-27",
+    title: "AxioDB CLI — Go-based command line interface with MongoDB shell syntax",
+    changes: [
+      "New: AxioDB CLI — a Go-based command line tool for interacting with AxioDB servers via the TCP protocol.",
+      "New: Interactive REPL mode with MongoDB shell syntax — use, show dbs, show collections, db.coll.find(), db.coll.insert(), and all CRUD operations.",
+      "New: All 21 TCP commands supported — database, collection, document CRUD, aggregation, indexing, ping, disconnect.",
+      "New: TLS support with --tls, --tls-cert, and --tls-skip-verify flags.",
+      "New: TCP authentication support with -u and -p flags.",
+      "New: Connection string support — axiodb://host:port format.",
+      "New: JSON and table output modes with --output flag.",
+      "New: Tab autocomplete in REPL mode.",
+      "New: Cross-platform binaries for 12 targets — Linux (amd64, arm64, 386, armv7), macOS (amd64, arm64), Windows (amd64, arm64, 386), FreeBSD, OpenBSD, NetBSD.",
+      "New: One-line install scripts for Linux/macOS (install.sh) and Windows (install.ps1) with auto OS/arch detection and checksum verification.",
+      "New: Automated GitHub releases with checksums.txt on version bump in cli/VERSION.",
+      "New: Version sync script (Scripts/versionController.sh) updates package.json, GUI/package.json, Document/package.json, and cli/VERSION together.",
+    ],
+  },
+  {
     version: "15.1.0",
     date: "2026-08-25",
     title: "Aggregation engine rewrite: 60+ operators, $lookup cross-collection joins, custom operator registry",


### PR DESCRIPTION
This pull request introduces and documents the new AxioDB CLI, a Go-based command line tool for interacting with AxioDB servers. The main changes include updating the changelog with a detailed entry for the CLI release and updating the CLI feature banner link in the introduction component.

**Documentation Updates:**

- Added a comprehensive changelog entry for version 15.2.0, detailing the release of the AxioDB CLI and its features, such as MongoDB shell syntax support, TLS, authentication, cross-platform binaries, and new install scripts.

**UI Improvements:**

- Updated the CLI feature banner in the `Introduction` component to link to the local `/cli` documentation page instead of the external GitHub releases page.