### PR TITLE
Update documentation for 11 new tools in AxioDB MCP integration

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -285,15 +285,17 @@ Register the endpoint (`http://localhost:27020/mcp`) with whichever AI tool you 
 | **Windsurf** | Add to `~/.codeium/windsurf/mcp_config.json`: `{ "mcpServers": { "axiodb": { "serverUrl": "..." } } }` |
 | **Google Antigravity** (IDE & CLI) | Add to `~/.gemini/config/mcp_config.json`: `{ "mcpServers": { "axiodb": { "serverUrl": "..." } } }` — note `serverUrl`, not `url` |
 
-**32 tools**, covering:
+**43 tools**, covering:
 
 - **Session**: `axiodb_login`, `axiodb_logout`, `axiodb_whoami`, `axiodb_change_own_password`
 - **Database**: create/delete/exists/instance-info
 - **Collection**: create/delete/exists/info
-- **Documents & Aggregation**: insert/insert-many/query/update/delete/count/aggregate
+- **Documents**: insert/insert-many/query/update/delete/find-by-ids/total-documents + `aggregate`
 - **Index**: create/drop/list
-- **Dashboard**: stats
-- **User & Role Management**: full CRUD on users and roles, Super Admin only
+- **Dashboard**: health + stats
+- **User Management**: list/create/update-role/reset-password/delete
+- **Role Management**: list/create/delete/permissions
+- **Transactions**: begin/insert/update/delete/savepoint/rollback-to/release/commit/rollback
 
 Every tool except `axiodb_login` requires a `sessionId` from a successful login - every
 subsequent call is checked against that logged-in user's actual RBAC role, exactly like the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "20.4.0",
+  "version": "20.4.1",
   "description": "SQLite Alternative for JavaScript. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request updates the documentation in `Docker/README.md` to reflect expanded tool coverage and more detailed API capabilities. The summary section now lists 43 supported tools (up from 32), with improved breakdowns of document, dashboard, user, role, and transaction operations.

Key documentation updates:

**Expanded tool support and feature breakdown:**

* Increased the number of supported tools from 32 to 43, reflecting new and expanded API endpoints.
* Updated the "Documents" section to specify separate endpoints for `find-by-ids` and `total-documents`, and clarified that `aggregate` is a distinct operation.
* Enhanced the "Dashboard" section to include both `health` and `stats` endpoints.
* Split user and role management into separate sections, detailing available CRUD and permission-related operations for each.
* Added a new "Transactions" section, listing supported transaction operations such as `begin`, `savepoint`, `rollback-to`, `release`, `commit`, and `rollback`.