### PR TITLE
Fix template literal syntax in crash recovery tests and update version

### DIFF
--- a/Test/modules/crash-recovery.test.js
+++ b/Test/modules/crash-recovery.test.js
@@ -267,7 +267,7 @@ class CrashRecoveryTests extends TestRunner {
 
         assert.ok(total > 0, 'Should have recovered at least some documents');
         assert.ok(catA > 0, 'Indexed $eq query should return matching documents');
-        assert.ok(emailMatch > 0, \`Exact email lookup for \${probeEmail} should work on recovered index\`);
+        assert.ok(emailMatch > 0, `Exact email lookup for ${probeEmail} should work on recovered index`);
         assert.ok(rangeMatch >= 0, 'Range query should not error after recovery');
 
         // Verify index meta file exists in JSONL format

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "20.4.1",
+  "version": "20.5.2",
   "description": "SQLite Alternative for JavaScript. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request contains minor updates, including a version bump and a small code style fix.

- Project version has been updated from 20.4.1 to 20.5.2 in `package.json`.
- Fixed a template string formatting issue in a test assertion in `Test/modules/crash-recovery.test.js`.