### PR TITLE
feat: update version to 20.5.5 in package.json

### DIFF
--- a/Document/package.json
+++ b/Document/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-react-typescript-starter",
   "private": true,
-  "version": "20.4.1",
+  "version": "20.5.5",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/Document/src/components/content/Introduction.tsx
+++ b/Document/src/components/content/Introduction.tsx
@@ -736,7 +736,7 @@ const Introduction: React.FC = () => {
                     <Sparkles className="h-3 w-3" />
                     NEW FEATURE
                   </div>
-                  <h3 className="text-xl sm:text-2xl md:text-3xl lg:text-2xl sm:text-3xl md:text-4xl font-extrabold text-gray-900 mb-3">
+                  <h3 className="text-xl sm:text-2xl md:text-3xl lg:text-2xl font-extrabold text-gray-900 mb-3">
                     Introducing AxioDBCloud
                   </h3>
                   <p className="text-xl text-accent-700 mb-4 leading-relaxed">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "20.5.4",
+  "version": "20.5.5",
   "description": "SQLite Alternative for JavaScript. Embedded NoSQL database for Node.js with MongoDB-style queries, zero native dependencies, built-in InMemoryCache, and web GUI. Perfect for desktop apps, CLI tools, and embedded systems. No compilation, no platform issues—pure JavaScript from npm install to production.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",


### PR DESCRIPTION
This pull request includes version updates for both the main package and the `vite-react-typescript-starter` example, as well as a minor UI fix in the `Introduction` component.

Version updates:

* Bumped the main package version in `package.json` from `20.5.4` to `20.5.5`.
* Bumped the example app version in `Document/package.json` from `20.4.1` to `20.5.5`.

UI improvements:

* Fixed redundant responsive text size classes in the `Introduction` component's heading by removing duplicate class names.