### PR TITLE
Require dbName in MessageValidator for GET_COLLECTION_INFO command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "axiodb",
-  "version": "22.2.1",
+  "version": "22.2.2",
   "description": "The embedded database for Node.js. Replaces SQLite, LowDB, NeDB & raw JSON files with MongoDB-style queries, ACID transactions, zero native dependencies, and built-in InMemoryCache. No compilation, no platform issues. Perfect for desktop apps, CLI tools, and embedded systems.",
   "main": "./lib/config/DB.js",
   "types": "./lib/config/DB.d.ts",

--- a/source/tcp/config/protocol.ts
+++ b/source/tcp/config/protocol.ts
@@ -179,9 +179,14 @@ export class MessageValidator {
       case CommandType.CREATE_COLLECTION:
       case CommandType.DELETE_COLLECTION:
       case CommandType.COLLECTION_EXISTS:
-      case CommandType.GET_COLLECTION_INFO:
         if (!params.dbName || !params.collectionName) {
           throw new Error(`${ErrorMessage.MISSING_REQUIRED_PARAMS}: dbName, collectionName`);
+        }
+        break;
+
+      case CommandType.GET_COLLECTION_INFO:
+        if (!params.dbName) {
+          throw new Error(`${ErrorMessage.MISSING_REQUIRED_PARAMS}: dbName`);
         }
         break;
 


### PR DESCRIPTION
This pull request introduces a minor version bump and refines validation logic for the `GET_COLLECTION_INFO` command. The most important changes are:

Versioning:

* Bumped the package version in `package.json` from `22.2.1` to `22.2.2`.

Validation logic improvements:

* Updated the `MessageValidator` in `protocol.ts` to change validation for `GET_COLLECTION_INFO`: now only `dbName` is required (previously both `dbName` and `collectionName` were required).…O command